### PR TITLE
fix: avoid unnecessary deployment of `llm canister` on mainnet

### DIFF
--- a/examples/icp-lookup-agent-motoko/dfx.json
+++ b/examples/icp-lookup-agent-motoko/dfx.json
@@ -8,7 +8,12 @@
       "type": "custom",
       "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
       "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
-      "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai"
+      "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
+      "remote": {
+        "id": {
+          "ic": "w36hm-eqaaa-aaaal-qr76a-cai"
+        }
+      }
     },
     "agent-backend": {
       "dependencies": [

--- a/examples/quickstart-agent-motoko/dfx.json
+++ b/examples/quickstart-agent-motoko/dfx.json
@@ -4,7 +4,12 @@
       "type": "custom",
       "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
       "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
-      "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai"
+      "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
+      "remote": {
+        "id": {
+          "ic": "w36hm-eqaaa-aaaal-qr76a-cai"
+        }
+      }
     },
     "agent-backend": {
       "dependencies": [


### PR DESCRIPTION
When the example is deployed on mainnet it shouldn't deploy the llm canister again but instead talk to the llm canister already present on mainnet with the canister id specified.