### PR TITLE
pin llm canister version to v0.1.2

### DIFF
--- a/examples/icp-lookup-agent-motoko/dfx.json
+++ b/examples/icp-lookup-agent-motoko/dfx.json
@@ -6,8 +6,8 @@
     },
     "llm": {
       "type": "custom",
-      "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
+      "wasm": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.wasm",
+      "candid": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.did",
       "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
       "remote": {
         "id": {

--- a/examples/icp-lookup-agent-rust/dfx.json
+++ b/examples/icp-lookup-agent-rust/dfx.json
@@ -6,8 +6,8 @@
     },
     "llm": {
       "type": "custom",
-      "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
+      "wasm": "https://github.com/dfinity/llm/v0.1.2/latest/download/llm-canister-ollama.wasm",
+      "candid": "https://github.com/dfinity/llm/v0.1.2/latest/download/llm-canister-ollama.did",
       "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
       "remote": {
         "id": {

--- a/examples/quickstart-agent-motoko/dfx.json
+++ b/examples/quickstart-agent-motoko/dfx.json
@@ -2,8 +2,8 @@
   "canisters": {
     "llm": {
       "type": "custom",
-      "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
+      "wasm": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.wasm",
+      "candid": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.did",
       "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
       "remote": {
         "id": {

--- a/examples/quickstart-agent-rust/dfx.json
+++ b/examples/quickstart-agent-rust/dfx.json
@@ -2,8 +2,8 @@
   "canisters": {
     "llm": {
       "type": "custom",
-      "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
+      "wasm": "https://github.com/dfinity/llm/releases/download/v0.1.2/llm-canister-ollama.wasm",
+      "candid": "https://github.com/dfinity/llm/releases/download/v0.1.2/llm-canister-ollama.did",
       "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
       "remote": {
         "id": {

--- a/examples/quickstart-agent-typescript/dfx.json
+++ b/examples/quickstart-agent-typescript/dfx.json
@@ -2,8 +2,8 @@
   "canisters": {
     "llm": {
       "type": "custom",
-      "wasm": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.wasm",
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
+      "wasm": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.wasm",
+      "candid": "https://github.com/dfinity/llm/releases/v0.1.2/download/llm-canister-ollama.did",
       "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
       "remote": {
         "id": {


### PR DESCRIPTION
The new llm canister that we'd like to release will not be compatible with this code version because it will require an initialisation argument to switch to the local ollama version which the current code in this repo uses.

Hence, we can pin the version to v0.1.2, then update the latest wasm module and update this code without any risk of breaking it.