### PR TITLE
Update with Groq API and latest llm-canister version

### DIFF
--- a/examples/icp-lookup-agent-motoko/README.md
+++ b/examples/icp-lookup-agent-motoko/README.md
@@ -8,9 +8,9 @@ It's meant to serve as an example for those who want to get started building age
 
 ![Screenshot of the agent](./screenshot.png)
 
-## Quickstart
+## Quickstart with Ollama
 Prerequisites
-- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) installed
 - [Ollama](https://ollama.com/) installed
 - [PNPM](https://pnpm.io/) installed
 
@@ -45,7 +45,6 @@ The LLM canister supports two backend options for processing prompts:
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
-> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
 
 #### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.

--- a/examples/icp-lookup-agent-motoko/README.md
+++ b/examples/icp-lookup-agent-motoko/README.md
@@ -8,10 +8,46 @@ It's meant to serve as an example for those who want to get started building age
 
 ![Screenshot of the agent](./screenshot.png)
 
+## Quickstart
+Prerequisites
+- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [Ollama](https://ollama.com/) installed
+- [PNPM](https://pnpm.io/) installed
+
+```bash
+# start ollama server
+ollama serve
+
+# Download the required model (one-time setup):
+ollama run llama3.1:8b
+
+# Start the local Internet Computer:
+dfx start --clean
+
+# Deploy the canisters:
+dfx deploy
+dfx deps deploy
+```
+
+Finally, access the agent at:
+```
+http://{FRONTEND_CANISTER_ID}.localhost:8080
+```
+
 ## Deployment
 
-### Running Ollama
+### LLM Backend Configuration
+The LLM canister supports two backend options for processing prompts:
 
+1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
+
+2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+
+You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
+
+> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
+
+#### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/) to install it. Once it's installed, run:
 
@@ -28,9 +64,18 @@ ollama run llama3.1:8b
 
 The above command will download an 8B parameter model, which is around 4GiB. Once the command executes and the model is loaded, you can terminate it. You won't need to do this step again.
 
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { ollama }, null)'`. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
+
+
+#### Configure with Groq
+As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+
 ### Deployment
 
-Once Ollama is running and the model has been downloaded, you can start dfx and deploy the canisters.
+Once your backend is set and initialized, you can start dfx and deploy the canisters.
 
 First, install `pnpm` and run `pnpm install` in the `src/frontend` directory.
 

--- a/examples/icp-lookup-agent-motoko/deps/pulled.json
+++ b/examples/icp-lookup-agent-motoko/deps/pulled.json
@@ -11,7 +11,7 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
       "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
       "init_guide": "",
       "init_arg": null,

--- a/examples/icp-lookup-agent-rust/README.md
+++ b/examples/icp-lookup-agent-rust/README.md
@@ -8,9 +8,9 @@ It's meant to serve as an example for those who want to get started building age
 
 ![Screenshot of the agent](./screenshot.png)
 
-## Quickstart
+## Quickstart with Ollama
 Prerequisites
-- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) installed
 - [Ollama](https://ollama.com/) installed
 - [PNPM](https://pnpm.io/) installed
 
@@ -45,7 +45,6 @@ The LLM canister supports two backend options for processing prompts:
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
-> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
 
 #### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.

--- a/examples/icp-lookup-agent-rust/README.md
+++ b/examples/icp-lookup-agent-rust/README.md
@@ -8,10 +8,46 @@ It's meant to serve as an example for those who want to get started building age
 
 ![Screenshot of the agent](./screenshot.png)
 
+## Quickstart
+Prerequisites
+- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [Ollama](https://ollama.com/) installed
+- [PNPM](https://pnpm.io/) installed
+
+```bash
+# start ollama server
+ollama serve
+
+# Download the required model (one-time setup):
+ollama run llama3.1:8b
+
+# Start the local Internet Computer:
+dfx start --clean
+
+# Deploy the canisters:
+dfx deploy
+dfx deps deploy
+```
+
+Finally, access the agent at:
+```
+http://{FRONTEND_CANISTER_ID}.localhost:8080
+```
+
 ## Deployment
 
-### Running Ollama
+### LLM Backend Configuration
+The LLM canister supports two backend options for processing prompts:
 
+1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
+
+2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+
+You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
+
+> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
+
+#### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/) to install it. Once it's installed, run:
 
@@ -28,9 +64,18 @@ ollama run llama3.1:8b
 
 The above command will download an 8B parameter model, which is around 4GiB. Once the command executes and the model is loaded, you can terminate it. You won't need to do this step again.
 
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { ollama }, null)'`. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
+
+
+#### Configure with Groq
+As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+
 ### Deployment
 
-Once Ollama is running and the model has been downloaded, you can start dfx and deploy the canisters.
+Once your backend is set and initialized, you can start dfx and deploy the canisters.
 
 First, install `pnpm` and run `pnpm install` in the `src/frontend` directory.
 

--- a/examples/icp-lookup-agent-rust/deps/pulled.json
+++ b/examples/icp-lookup-agent-rust/deps/pulled.json
@@ -11,7 +11,7 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
       "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
       "init_guide": "",
       "init_arg": null,

--- a/examples/quickstart-agent-motoko/README.md
+++ b/examples/quickstart-agent-motoko/README.md
@@ -5,9 +5,9 @@ It's meant to serve as a boilerplate project for those who want to get started b
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
-## Quickstart
+## Quickstart with Ollama
 Prerequisites
-- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) installed
 - [Ollama](https://ollama.com/) installed
 - [PNPM](https://pnpm.io/) installed
 
@@ -42,7 +42,6 @@ The LLM canister supports two backend options for processing prompts:
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
-> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
 
 #### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.

--- a/examples/quickstart-agent-motoko/README.md
+++ b/examples/quickstart-agent-motoko/README.md
@@ -1,15 +1,50 @@
-# Quickstart AI Agent (Motoko)
+# AI Agent (Motoko)
 
 This is a simple agent that simply relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
+## Quickstart
+Prerequisites
+- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [Ollama](https://ollama.com/) installed
+- [PNPM](https://pnpm.io/) installed
+
+```bash
+# start ollama server
+ollama serve
+
+# Download the required model (one-time setup):
+ollama run llama3.1:8b
+
+# Start the local Internet Computer:
+dfx start --clean
+
+# Deploy the canisters:
+dfx deploy
+dfx deps deploy
+```
+
+Finally, access the agent at:
+```
+http://{FRONTEND_CANISTER_ID}.localhost:8080
+```
 
 ## Deployment
 
-### Running Ollama
+### LLM Backend Configuration
+The LLM canister supports two backend options for processing prompts:
 
+1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
+
+2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+
+You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
+
+> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
+
+#### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/) to install it. Once it's installed, run:
 
@@ -26,9 +61,18 @@ ollama run llama3.1:8b
 
 The above command will download an 8B parameter model, which is around 4GiB. Once the command executes and the model is loaded, you can terminate it. You won't need to do this step again.
 
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { ollama }, null)'`. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
+
+
+#### Configure with Groq
+As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+
 ### Deployment
 
-Once Ollama is running and the model has been downloaded, you can start dfx and deploy the canisters.
+Once your backend is set and initialized, you can start dfx and deploy the canisters.
 
 First, install `pnpm` and run `pnpm install` in the `src/frontend` directory.
 

--- a/examples/quickstart-agent-motoko/README.md
+++ b/examples/quickstart-agent-motoko/README.md
@@ -1,4 +1,4 @@
-# AI Agent (Motoko)
+# Quickstart AI Agent (Motoko)
 
 This is a simple agent that simply relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -1,4 +1,4 @@
-# AI Agent (Rust)
+# Quickstart AI Agent (Rust)
 
 This is a simple agent that simply relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -5,9 +5,9 @@ It's meant to serve as a boilerplate project for those who want to get started b
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
-## Quickstart
+## Quickstart with Ollama
 Prerequisites
-- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) installed
 - [Ollama](https://ollama.com/) installed
 - [PNPM](https://pnpm.io/) installed
 
@@ -42,7 +42,6 @@ The LLM canister supports two backend options for processing prompts:
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
-> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
 
 #### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -1,15 +1,50 @@
-# Quickstart AI Agent (Rust)
+# AI Agent (Rust)
 
 This is a simple agent that simply relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
+## Quickstart
+Prerequisites
+- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [Ollama](https://ollama.com/) installed
+- [PNPM](https://pnpm.io/) installed
+
+```bash
+# start ollama server
+ollama serve
+
+# Download the required model (one-time setup):
+ollama run llama3.1:8b
+
+# Start the local Internet Computer:
+dfx start --clean
+
+# Deploy the canisters:
+dfx deploy
+dfx deps deploy
+```
+
+Finally, access the agent at:
+```
+http://{FRONTEND_CANISTER_ID}.localhost:8080
+```
 
 ## Deployment
 
-### Running Ollama
+### LLM Backend Configuration
+The LLM canister supports two backend options for processing prompts:
 
+1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
+
+2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+
+You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
+
+> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
+
+#### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/) to install it. Once it's installed, run:
 
@@ -26,9 +61,18 @@ ollama run llama3.1:8b
 
 The above command will download an 8B parameter model, which is around 4GiB. Once the command executes and the model is loaded, you can terminate it. You won't need to do this step again.
 
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { ollama }, null)'`. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
+
+
+#### Configure with Groq
+As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+
 ### Deployment
 
-Once Ollama is running and the model has been downloaded, you can start dfx and deploy the canisters.
+Once your backend is set and initialized, you can start dfx and deploy the canisters.
 
 First, install `pnpm` and run `pnpm install` in the `src/frontend` directory.
 

--- a/examples/quickstart-agent-rust/deps/pulled.json
+++ b/examples/quickstart-agent-rust/deps/pulled.json
@@ -2,7 +2,7 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
       "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
       "init_guide": "",
       "init_arg": null,

--- a/examples/quickstart-agent-typescript/README.md
+++ b/examples/quickstart-agent-typescript/README.md
@@ -1,4 +1,4 @@
-# AI Agent (Typescript)
+# Quickstart AI Agent (Typescript)
 
 This is a simple agent that relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.

--- a/examples/quickstart-agent-typescript/README.md
+++ b/examples/quickstart-agent-typescript/README.md
@@ -1,15 +1,50 @@
-# Quickstart AI Agent (Typescript)
+# AI Agent (Typescript)
 
 This is a simple agent that relays whatever messages the user gives to the underlying models without any modification.
 It's meant to serve as a boilerplate project for those who want to get started building agents on the IC.
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
+## Quickstart
+Prerequisites
+- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
+- [Ollama](https://ollama.com/) installed
+- [PNPM](https://pnpm.io/) installed
+
+```bash
+# start ollama server
+ollama serve
+
+# Download the required model (one-time setup):
+ollama run llama3.1:8b
+
+# Start the local Internet Computer:
+dfx start --clean
+
+# Deploy the canisters:
+dfx deploy
+dfx deps deploy
+```
+
+Finally, access the agent at:
+```
+http://{FRONTEND_CANISTER_ID}.localhost:8080
+```
 
 ## Deployment
 
-### Running Ollama
+### LLM Backend Configuration
+The LLM canister supports two backend options for processing prompts:
 
+1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
+
+2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+
+You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
+
+> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
+
+#### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.
 See the documentation on the [Ollama website](https://ollama.com/) to install it. Once it's installed, run:
 
@@ -26,14 +61,18 @@ ollama run llama3.1:8b
 
 The above command will download an 8B parameter model, which is around 4GiB. Once the command executes and the model is loaded, you can terminate it. You won't need to do this step again.
 
-Once Ollama is running and the model has been downloaded, you can start dfx and deploy the canisters.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { ollama }, null)'`. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
+
+
+#### Configure with Groq
+As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
-
-This project contains a `mise.toml` file with the version of `npm` that it needs. We recommend using `mise`, otherwise you can download `npm` yourself.
-
+Once your backend is set and initialized, you can start dfx and deploy the canisters.
 First, run `npm install` to install the azle backend.
-
 Second, run `npm install` in the `src/frontend` directory to install the dependencies for the frontend canister.
 
 Then, in one terminal window, run:

--- a/examples/quickstart-agent-typescript/README.md
+++ b/examples/quickstart-agent-typescript/README.md
@@ -5,32 +5,6 @@ It's meant to serve as a boilerplate project for those who want to get started b
 
 ![Screenshot of the quickstart agent](../../screenshot.png)
 
-## Quickstart
-Prerequisites
-- [DFX](https://internetcomputer.org/docs/current/developer-docs/smart-contracts/getting-started/hello10mins) installed
-- [Ollama](https://ollama.com/) installed
-- [PNPM](https://pnpm.io/) installed
-
-```bash
-# start ollama server
-ollama serve
-
-# Download the required model (one-time setup):
-ollama run llama3.1:8b
-
-# Start the local Internet Computer:
-dfx start --clean
-
-# Deploy the canisters:
-dfx deploy
-dfx deps deploy
-```
-
-Finally, access the agent at:
-```
-http://{FRONTEND_CANISTER_ID}.localhost:8080
-```
-
 ## Deployment
 
 ### LLM Backend Configuration

--- a/examples/quickstart-agent-typescript/README.md
+++ b/examples/quickstart-agent-typescript/README.md
@@ -16,7 +16,6 @@ The LLM canister supports two backend options for processing prompts:
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
-> **Note**: The llm canister currently only supports LLama3.1 8B independently of the backend that you choose. Further model support will be added in the near future.
 
 #### Configure with Ollama
 To be able to test the agent locally, you'll need a server for processing the agent's prompts. For that, we'll use `ollama`, which is a tool that can download and serve LLMs.

--- a/examples/quickstart-agent-typescript/deps/pulled.json
+++ b/examples/quickstart-agent-typescript/deps/pulled.json
@@ -2,7 +2,7 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
       "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
       "init_guide": "",
       "init_arg": null,


### PR DESCRIPTION
This MR updates this repo to include the latest llm-canister updates:
- Provide usage examples on how to use the Groq API for local development
- Add proper arguments to launch the Groq or Ollama backend

Unfortunately, markdown does not support including files as text. That would make it much easier to maintain.