### PR TITLE
feat: OpenRouter documentation and release

### DIFF
--- a/examples/icp-lookup-agent-motoko/README.md
+++ b/examples/icp-lookup-agent-motoko/README.md
@@ -41,7 +41,8 @@ The LLM canister supports two backend options for processing prompts:
 
 1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
 
-2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+2. **OpenRouter API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key.
+Note: This used to Groq for v0.2.1 and lower.
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
@@ -67,10 +68,10 @@ Initialise the llm canister with `dfx deps init llm --argument '(opt variant { o
 This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
 
 
-#### Configure with Groq
-As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+#### Configure with OpenRouter
+As an alternative you can use the [OpenRouter API](https://openrouter.ai/). You will need to create an [API key](https://openrouter.ai/settings/keys) first.
 
-Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { openrouter = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
 

--- a/examples/icp-lookup-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/icp-lookup-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,11 +5,6 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-type backend_config = variant {
-  groq : record { api_key : text };
-  worker;
-  ollama;
-};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/icp-lookup-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/icp-lookup-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,6 +5,11 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
+type backend_config = variant {
+  worker;
+  ollama;
+  openrouter : record { api_key : text };
+};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/icp-lookup-agent-motoko/deps/pulled.json
+++ b/examples/icp-lookup-agent-motoko/deps/pulled.json
@@ -11,8 +11,8 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
-      "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",

--- a/examples/icp-lookup-agent-rust/README.md
+++ b/examples/icp-lookup-agent-rust/README.md
@@ -41,7 +41,8 @@ The LLM canister supports two backend options for processing prompts:
 
 1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
 
-2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+2. **OpenRouter API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key.
+Note: This used to Groq for v0.2.1 and lower.
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
@@ -67,10 +68,10 @@ Initialise the llm canister with `dfx deps init llm --argument '(opt variant { o
 This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
 
 
-#### Configure with Groq
-As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+#### Configure with OpenRouter
+As an alternative you can use the [OpenRouter API](https://openrouter.ai/). You will need to create an [API key](https://openrouter.ai/settings/keys) first.
 
-Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { openrouter = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
 

--- a/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,11 +5,6 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-type backend_config = variant {
-  groq : record { api_key : text };
-  worker;
-  ollama;
-};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,6 +5,11 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
+type backend_config = variant {
+  worker;
+  ollama;
+  openrouter : record { api_key : text };
+};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/icp-lookup-agent-rust/deps/pulled.json
+++ b/examples/icp-lookup-agent-rust/deps/pulled.json
@@ -11,8 +11,8 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
-      "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",

--- a/examples/quickstart-agent-motoko/README.md
+++ b/examples/quickstart-agent-motoko/README.md
@@ -38,7 +38,8 @@ The LLM canister supports two backend options for processing prompts:
 
 1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
 
-2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+2. **OpenRouter API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key.
+Note: This used to Groq for v0.2.1 and lower.
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
@@ -64,10 +65,10 @@ Initialise the llm canister with `dfx deps init llm --argument '(opt variant { o
 This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
 
 
-#### Configure with Groq
-As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+#### Configure with OpenRouter
+As an alternative you can use the [OpenRouter API](https://openrouter.ai/). You will need to create an [API key](https://openrouter.ai/settings/keys) first.
 
-Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { openrouter = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
 

--- a/examples/quickstart-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,11 +5,6 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-type backend_config = variant {
-  groq : record { api_key : text };
-  worker;
-  ollama;
-};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-motoko/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,6 +5,11 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
+type backend_config = variant {
+  worker;
+  ollama;
+  openrouter : record { api_key : text };
+};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-motoko/deps/pulled.json
+++ b/examples/quickstart-agent-motoko/deps/pulled.json
@@ -2,8 +2,8 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
-      "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -38,7 +38,8 @@ The LLM canister supports two backend options for processing prompts:
 
 1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
 
-2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+2. **OpenRouter API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key.
+Note: This used to Groq for v0.2.1 and lower.
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
@@ -64,10 +65,10 @@ Initialise the llm canister with `dfx deps init llm --argument '(opt variant { o
 This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
 
 
-#### Configure with Groq
-As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+#### Configure with OpenRouter
+As an alternative you can use the [OpenRouter API](https://openrouter.ai/). You will need to create an [API key](https://openrouter.ai/settings/keys) first.
 
-Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { openrouter = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
 

--- a/examples/quickstart-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,11 +5,7 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-type backend_config = variant {
-  groq : record { api_key : text };
-  worker;
-  ollama;
-};
+
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,7 +5,11 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-
+type backend_config = variant {
+  worker;
+  ollama;
+  openrouter : record { api_key : text };
+};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-rust/deps/pulled.json
+++ b/examples/quickstart-agent-rust/deps/pulled.json
@@ -2,8 +2,8 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
-      "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",

--- a/examples/quickstart-agent-typescript/README.md
+++ b/examples/quickstart-agent-typescript/README.md
@@ -12,7 +12,8 @@ The LLM canister supports two backend options for processing prompts:
 
 1. **Ollama (Local)**: A free, self-hosted solution that runs on your local machine. Perfect for testing and development without any costs.
 
-2. **Groq API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key (free for testing).
+2. **OpenRouter API**: A cloud-based solution that can handle larger models that might be too resource-intensive for local machines. Requires an API key.
+Note: This used to Groq for v0.2.1 and lower.
 
 You can select your preferred backend by initialising the llm dependency through `dfx deps init` (see below for init arguments).
 
@@ -38,10 +39,10 @@ Initialise the llm canister with `dfx deps init llm --argument '(opt variant { o
 This backend is also the default backend and thus will work without calling the initialisation if the `deps/init.json` has not been changed.
 
 
-#### Configure with Groq
-As an alternative you can use the [Groq API](https://console.groq.com/home). You will need to create an [API key](https://console.groq.com/keys) first (free for testing purposes).
+#### Configure with OpenRouter
+As an alternative you can use the [OpenRouter API](https://openrouter.ai/). You will need to create an [API key](https://openrouter.ai/settings/keys) first.
 
-Initialise the llm canister with `dfx deps init llm --argument '(opt variant { groq = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
+Initialise the llm canister with `dfx deps init llm --argument '(opt variant { openrouter = record { api_key = "{YOUR_API_KEY}" } }, null)'`, replacing `YOUR_API_KEY` with your own. You can also inspect `deps/init.json` to see which backend will be used when launching the canister.
 
 ### Deployment
 Once your backend is set and initialized, you can start dfx and deploy the canisters.

--- a/examples/quickstart-agent-typescript/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-typescript/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,11 +5,6 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
-type backend_config = variant {
-  groq : record { api_key : text };
-  worker;
-  ollama;
-};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-typescript/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/quickstart-agent-typescript/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -5,6 +5,11 @@ type assistant_message = record {
     function : record { name : text; arguments : vec tool_call_argument };
   };
 };
+type backend_config = variant {
+  worker;
+  ollama;
+  openrouter : record { api_key : text };
+};
 type chat_message_v0 = record {
   content : text;
   role : variant { user; assistant; system };

--- a/examples/quickstart-agent-typescript/deps/pulled.json
+++ b/examples/quickstart-agent-typescript/deps/pulled.json
@@ -2,8 +2,8 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "52f23a42ec2dc15343cc01837306ad632a2d82219a4e9a3395cb060faa53489b",
-      "wasm_hash_download": "dffae06470200900780415167242d3eb9c68afd016b9c7db0b06fc825ff89dd2",
+      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",


### PR DESCRIPTION
# Update backend initialization documentation and clean up configuration
**Changes**
**Documentation:** Updated initialization examples to use OpenRouter instead of Groq as the backend provider.
**Configuration cleanup:** Removed unused `backend_config` parameter from candid files to simplify the interface.