### PR TITLE
feat: upgrade motoko and rust examples with latest lib versions

### DIFF
--- a/examples/icp-lookup-agent-motoko/deps/pulled.json
+++ b/examples/icp-lookup-agent-motoko/deps/pulled.json
@@ -11,7 +11,7 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,

--- a/examples/icp-lookup-agent-motoko/mops.toml
+++ b/examples/icp-lookup-agent-motoko/mops.toml
@@ -1,3 +1,3 @@
 [dependencies]
-llm = "1.2.0"
+llm = "2.1.0"
 base = "0.14.3"

--- a/examples/icp-lookup-agent-motoko/src/backend/main.mo
+++ b/examples/icp-lookup-agent-motoko/src/backend/main.mo
@@ -62,9 +62,14 @@ Follow these steps rigorously:
 
   public func chat(messages : [LLM.ChatMessage]) : async Text {
     // Prepend the system prompt to the messages.
-    let allMessages = Array.append([{ role = #system_; content = SYSTEM_PROMPT }], messages);
+    let systemMsg : LLM.ChatMessage = #system_({ content = SYSTEM_PROMPT });
+    let allMessages = Array.append([systemMsg], messages);
 
-    let answer = await LLM.chat(#Llama3_1_8B, allMessages);
+    let response = await LLM.chat(#Llama3_1_8B).withMessages(allMessages).send();
+    let answer = switch (response.message.content) {
+      case (?text) text;
+      case null "";
+    };
     if (Text.startsWith(answer, #text "LOOKUP(")) {
       // Extract the account from LOOKUP(account)
       let account = Text.trimStart(Text.trimEnd(answer, #char ')'), #text "LOOKUP(");

--- a/examples/icp-lookup-agent-motoko/src/frontend/src/App.ts
+++ b/examples/icp-lookup-agent-motoko/src/frontend/src/App.ts
@@ -19,10 +19,8 @@ class App {
 
     this.chat = [
       {
-        role: { assistant: null },
-        content:
-          "I'm a sovereign AI agent living on the Internet Computer. Ask me anything.",
-      },
+        assistant: { content: ["I'm a sovereign AI agent living on the Internet Computer. Ask me anything."], tool_calls: [] }
+      }
     ];
 
     this.#render();
@@ -41,10 +39,18 @@ class App {
 
   // Appends a message to the chat box.
   appendMessage(message: ChatMessage) {
-    let side = "user" in message.role ? "right" : "left";
-    let img = "user" in message.role ? PERSON_IMG : BOT_IMG;
-    let name = "user" in message.role ? "User" : "Assistant";
-    let text = message.content;
+    let side = "user" in message ? "right" : "left";
+    let img = "user" in message ? PERSON_IMG : BOT_IMG;
+    let name = "user" in message ? "User" : "Assistant";
+    let text = "user" in message
+      ? message.user.content
+      : "assistant" in message
+        ? (message.assistant.content[0] || "")
+        : "system" in message
+          ? message.system.content
+          : "tool" in message
+            ? message.tool.content
+            : "";
 
     const msgHTML = `
 <div class="msg ${side}-msg">
@@ -81,8 +87,7 @@ class App {
 
       // Add the agent's response.
       this.chat.push({
-        role: { assistant: null },
-        content: response,
+        assistant: { content: [response], tool_calls: [] }
       });
     } catch (e) {
       console.log(e);
@@ -117,15 +122,13 @@ class App {
     if (!msgText) return;
 
     this.chat.push({
-      role: { user: null },
-      content: msgText,
+      user: { content: msgText }
     });
     msgerInput.value = "";
 
     // Add user message to chat and show "thinking..." while waiting for response.
     this.chat.push({
-      role: { assistant: null },
-      content: "Thinking...",
+      assistant: { content: ["Thinking..."], tool_calls: [] }
     });
 
     // Disable the send button.

--- a/examples/icp-lookup-agent-rust/Cargo.lock
+++ b/examples/icp-lookup-agent-rust/Cargo.lock
@@ -245,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "ic-llm"
-version = "0.4.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2ff641b428ea25ead456b4ec27a13c04f7fbf10785277fada583150b484c8d"
+checksum = "fa0e74462ec292f110b27f9c50d7b152f9172be2326053cc1290d58bcf438c2c"
 dependencies = [
  "candid",
  "ic-cdk 0.17.1",

--- a/examples/icp-lookup-agent-rust/deps/pulled.json
+++ b/examples/icp-lookup-agent-rust/deps/pulled.json
@@ -11,7 +11,7 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,

--- a/examples/icp-lookup-agent-rust/src/backend/Cargo.toml
+++ b/examples/icp-lookup-agent-rust/src/backend/Cargo.toml
@@ -13,4 +13,4 @@ crate-type = ["cdylib"]
 candid = "0.10"
 ic-cdk = "0.16"
 ic-ledger-types = "0.14.0"
-ic-llm = "0.4.0"
+ic-llm = "1.1.0"

--- a/examples/icp-lookup-agent-rust/src/backend/backend.did
+++ b/examples/icp-lookup-agent-rust/src/backend/backend.did
@@ -1,6 +1,20 @@
-type chat_message = record {
-  role: variant { user; system; assistant };
-  content: text;
+type chat_message = variant {
+  tool : record { content : text; tool_call_id : text };
+  user : record { content : text };
+  assistant : record {
+    content : opt text;
+    tool_calls : vec record {
+      id : text;
+      function : record {
+        name : text;
+        arguments : vec record {
+          name : text;
+          value : text;
+        };
+      }
+    };
+  };
+  system : record { content : text };
 };
 
 service: {

--- a/examples/icp-lookup-agent-rust/src/frontend/src/App.ts
+++ b/examples/icp-lookup-agent-rust/src/frontend/src/App.ts
@@ -19,9 +19,10 @@ class App {
 
     this.chat = [
       {
-        role: { assistant: null },
-        content:
-          "I'm an agent specializing in looking up ICP balances. Ask me for an ICP balance to lookup.",
+        assistant: {
+          content: ["I'm an agent specializing in looking up ICP balances. Ask me for an ICP balance to lookup."],
+          tool_calls: [],
+        },
       },
     ];
 
@@ -41,10 +42,16 @@ class App {
 
   // Appends a message to the chat box.
   appendMessage(message: chat_message) {
-    let side = "user" in message.role ? "right" : "left";
-    let img = "user" in message.role ? PERSON_IMG : BOT_IMG;
-    let name = "user" in message.role ? "User" : "Assistant";
-    let text = message.content;
+    let side = "user" in message ? "right" : "left";
+    let img = "user" in message ? PERSON_IMG : BOT_IMG;
+    let name = "user" in message ? "User" : "Assistant";
+    let text = "user" in message 
+      ? message.user.content 
+      : "assistant" in message 
+        ? message.assistant.content[0] ?? ""
+        : "system" in message
+          ? message.system.content
+          : message.tool.content;
 
     const msgHTML = `
 <div class="msg ${side}-msg">
@@ -81,8 +88,10 @@ class App {
 
       // Add the agent's response.
       this.chat.push({
-        role: { assistant: null },
-        content: response,
+              assistant: {
+        content: [response],
+        tool_calls: [],
+      }
       });
     } catch (e) {
       console.log(e);
@@ -117,15 +126,18 @@ class App {
     if (!msgText) return;
 
     this.chat.push({
-      role: { user: null },
-      content: msgText,
+      user: {
+        content: msgText,
+      }
     });
     msgerInput.value = "";
 
     // Add user message to chat and show "thinking..." while waiting for response.
     this.chat.push({
-      role: { assistant: null },
-      content: "Thinking...",
+      assistant: {
+        content: ["Thinking..."],
+        tool_calls: [],
+      }
     });
 
     // Disable the send button.

--- a/examples/quickstart-agent-motoko/deps/pulled.json
+++ b/examples/quickstart-agent-motoko/deps/pulled.json
@@ -2,7 +2,7 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,

--- a/examples/quickstart-agent-motoko/mops.toml
+++ b/examples/quickstart-agent-motoko/mops.toml
@@ -1,2 +1,2 @@
 [dependencies]
-llm = "2.0.0"
+llm = "2.1.0"

--- a/examples/quickstart-agent-rust/Cargo.lock
+++ b/examples/quickstart-agent-rust/Cargo.lock
@@ -230,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "ic-llm"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d9af93db5bb302b699cc03acf3d5912fea8b2c2d4d1b8500fb83a234066864"
+checksum = "fa0e74462ec292f110b27f9c50d7b152f9172be2326053cc1290d58bcf438c2c"
 dependencies = [
  "candid",
  "ic-cdk 0.17.1",

--- a/examples/quickstart-agent-rust/deps/pulled.json
+++ b/examples/quickstart-agent-rust/deps/pulled.json
@@ -2,7 +2,7 @@
   "canisters": {
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "786bd458da629545c2ddc8f5824363480f13c869b6abe078c5e9dc5e34a63733",
+      "wasm_hash": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
       "init_guide": "",
       "init_arg": null,

--- a/examples/quickstart-agent-rust/src/backend/Cargo.toml
+++ b/examples/quickstart-agent-rust/src/backend/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 [dependencies]
 candid = "0.10"
 ic-cdk = "0.16"
-ic-llm = "1.0.0"
+ic-llm = "1.1.0"

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -1,5 +1,4 @@
 import Tool "./tool";
-import Array "mo:base/Array";
 
 module {
     private let llmCanister = actor ("w36hm-eqaaa-aaaal-qr76a-cai") : actor {


### PR DESCRIPTION
This MR upgrade the Rust and Motoko examples to their latest library versions supporting more models.

- Bump Motoko LLM library to `2.1.0` for both examples
- Bump Rust LLM library to `1.1.0` for both examples
- Remove unneeded import in Motoko library


Tested through deploying the examples and using a newer model.