### PR TITLE
feat: Added forum badge to top-level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # LLMs on the IC
 
+
+<div>
+  <p>
+    <a href="https://forum.dfinity.org/t/introducing-the-llm-canister-deploy-ai-agents-with-a-few-lines-of-code/"><img alt="Chat on the Forum" src="https://img.shields.io/badge/help-post%20on%20forum.dfinity.org-yellow"></a>
+  </p>
+</div>
+
+
 This repo contains libraries and examples of how to use the [LLM canister](https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=w36hm-eqaaa-aaaal-qr76a-cai) on the IC.
 
 ## Libraries

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 <div>
   <p>
-    <a href="https://forum.dfinity.org/t/introducing-the-llm-canister-deploy-ai-agents-with-a-few-lines-of-code/"><img alt="Chat on the Forum" src="https://img.shields.io/badge/help-post%20on%20forum.dfinity.org-yellow"></a>
+    <a href="https://forum.dfinity.org"><img alt="Chat on the Forum" src="https://img.shields.io/badge/help-post%20on%20forum.dfinity.org-yellow"></a>
   </p>
 </div>
 


### PR DESCRIPTION
Added the forum badge to the top-level readme. Not sure if we want to link directly to the LLM-canister post or just the general link to the forum. @ielashi , @letmejustputthishere  what do you think?