### PR TITLE
feat: switch ICP lookup Rust example to use tools

### DIFF
--- a/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
+++ b/examples/icp-lookup-agent-rust/deps/candid/w36hm-eqaaa-aaaal-qr76a-cai.did
@@ -31,20 +31,21 @@ type config = record {
   workers_whitelist : variant { all; some : vec principal };
   api_disabled : bool;
 };
-type parameter = record {
+type parameters = record {
   "type" : text;
   properties : opt vec property;
   required : opt vec text;
 };
 type property = record {
   enum : opt vec text;
+  name : text;
   "type" : text;
   description : opt text;
 };
 type tool = variant {
   function : record {
     name : text;
-    parameters : opt vec parameter;
+    parameters : opt parameters;
     description : opt text;
   };
 };

--- a/examples/icp-lookup-agent-rust/deps/pulled.json
+++ b/examples/icp-lookup-agent-rust/deps/pulled.json
@@ -11,8 +11,8 @@
     },
     "w36hm-eqaaa-aaaal-qr76a-cai": {
       "name": "llm",
-      "wasm_hash": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
-      "wasm_hash_download": "31c5d981ac88f2861ea2e75108f5c998035814f2648068e079901cbf1916deac",
+      "wasm_hash": "b4ac8ec1cbd1505e217dd52decb9f52c60d3c1a818c31876508490e59448e1f7",
+      "wasm_hash_download": "9fc6a172b13289428c6975895382c3c923fb641bcd8e8a5168469298c3cff310",
       "init_guide": "",
       "init_arg": null,
       "candid_args": "(opt backend_config, opt config)",

--- a/examples/icp-lookup-agent-rust/src/backend/src/lib.rs
+++ b/examples/icp-lookup-agent-rust/src/backend/src/lib.rs
@@ -10,7 +10,6 @@ const MODEL: Model = Model::Qwen3_32B;
 /// Lookup the balance of an ICP account.
 async fn lookup_account(account: &str) -> String {
     if account.len() != 64 {
-        ic_cdk::println!("Account must be 64 characters long but got {} for input \"{}\"", account.len(), account);
         return "Account must be 64 characters long".to_string();
     }
 
@@ -61,7 +60,6 @@ async fn chat(messages: Vec<ChatMessage>) -> String {
 
         // Process each tool call
         for tool_call in &response.message.tool_calls {
-            ic_cdk::println!("tool_call: {:?}", tool_call);
             let tool_result = match tool_call.function.name.as_str() {
                 "lookup_icp_balance" => {
                     let account = tool_call.function.get("account").expect("account is required");
@@ -69,8 +67,6 @@ async fn chat(messages: Vec<ChatMessage>) -> String {
                 }
                 _ => format!("Unknown tool: {}", tool_call.function.name)
             };
-
-            ic_cdk::println!("tool_result: {:?}", tool_result);
 
             // Add tool result to conversation
             all_messages.push(ChatMessage::Tool {
@@ -85,12 +81,9 @@ async fn chat(messages: Vec<ChatMessage>) -> String {
             .send()
             .await;
 
-        ic_cdk::println!("final_response: {:?}", final_response);
-
         final_response.message.content.unwrap_or_default()
     } else {
         // No tool calls needed, return direct response
-        ic_cdk::println!("response without tool calls: {:?}", response);
         response.message.content.unwrap_or_default()
     }
 }

--- a/examples/icp-lookup-agent-rust/src/backend/src/lib.rs
+++ b/examples/icp-lookup-agent-rust/src/backend/src/lib.rs
@@ -48,13 +48,11 @@ async fn chat(messages: Vec<ChatMessage>) -> String {
             .build()
     ];
 
-    ic_cdk::println!("all tools: {:?}", tools);
-
-    let response = ic_llm::chat(MODEL)
+    let chat = ic_llm::chat(MODEL)
         .with_messages(all_messages.clone())
-        .with_tools(tools)
-        .send()
-        .await;
+        .with_tools(tools);
+
+    let response = chat.send().await;
 
     // Check if LLM wants to use tools
     if !response.message.tool_calls.is_empty() {
@@ -66,8 +64,7 @@ async fn chat(messages: Vec<ChatMessage>) -> String {
             ic_cdk::println!("tool_call: {:?}", tool_call);
             let tool_result = match tool_call.function.name.as_str() {
                 "lookup_icp_balance" => {
-                    let account = tool_call.function.get("account").unwrap_or_default();
-                    ic_cdk::println!("account: {:?}", account);
+                    let account = tool_call.function.get("account").expect("account is required");
                     lookup_account(&account).await
                 }
                 _ => format!("Unknown tool: {}", tool_call.function.name)


### PR DESCRIPTION
This PR moves the ICP lookup example to use tool-calling.

Tested with:

```
dfx start --clean --background
dfx deps pull
dfx deps deploy
dfx deploy
```

Open your browser at the interface and paste in your address.
