### PR TITLE
docs: Reference tool call examples

### DIFF
--- a/motoko/README.md
+++ b/motoko/README.md
@@ -113,6 +113,8 @@ actor {
 
 ### Advanced Usage with Tools
 
+For a complete example of using tools with the LLM library, see the [ICP Lookup Agent example](examples/icp-lookup-agent-motoko).
+
 #### Understanding Tools
 
 **Tools** are custom functions that you define and make available to the LLM. They allow the AI to perform actions beyond just generating text responses. When you provide tools to the LLM, it can decide when and how to use them based on the user's request.

--- a/rust/README.md
+++ b/rust/README.md
@@ -111,6 +111,8 @@ async fn example() {
 
 ### Advanced Usage with Tools
 
+For a complete example of using tools with the LLM library, see the [ICP Lookup Agent example](examples/icp-lookup-agent-rust).
+
 #### Understanding Tools
 
 **Tools** are custom functions that you define and make available to the LLM. 


### PR DESCRIPTION
Reference the newly ported tool call examples so users can see and use the real examples rather than just code snippets.