### PR TITLE
feat(motoko): resolve LLM canister via env var and skip cycles for free models

### DIFF
--- a/motoko/README.md
+++ b/motoko/README.md
@@ -5,85 +5,30 @@ A library for making requests to the LLM canister on the Internet Computer.
 ## Supported Models
 
 Models are identified by their string name (passed to `LLM.prompt` and
-`LLM.chat`). The available models are:
+`LLM.chat`). See the [Intelligence Gateway Homepage](https://inference.internetcomputer.org/) for the authoritative, up-to-date list.
 
-| Model string      | Pricing |
-| ----------------- | ------- |
-| `"llama3.1:8b"`   | Free    |
-| `"qwen3:32b"`     | Free    |
-| `"llama4-scout"`  | Free    |
-| `"qwen2.5:0.5b"`  | Free    |
-| `"gemma3:27b"`    | Paid    |
-| `"z-ai:glm-5.2"`  | Paid    |
+## Paying for Models
 
-Models are added frequently — see the [LLM canister](../README.md) for the
-authoritative, up-to-date list.
+For paid models, `send()` attaches 100B cycles to the request — the model
+charges only what it needs and refunds the rest — **so the calling canister must
+hold at least 100B cycles or the call traps**. Free models are called with no
+cycles attached, so the caller doesn't need to hold any.
 
-### Paying for models
+## Local Development
 
-`send()` automatically attaches 100B cycles to every request. Paid models are
-charged from those cycles (any unused portion is refunded); free models refund
-the full amount. Because cycles are always attached, **the calling canister must
-hold at least 100B cycles when `send()` runs, or the call traps** — this applies
-even when using a free model.
+The library resolves which `llm` canister to call at runtime, so the same code
+works locally and on mainnet:
 
-## Local Development Setup
+- **Mainnet:** it calls the canonical LLM canister
+  (`w36hm-eqaaa-aaaal-qr76a-cai`), which requires no API key.
+- **Locally:** `icp deploy` injects the local `llm` canister's principal as the
+  `PUBLIC_CANISTER_ID:llm` environment variable and the library picks it up
+  automatically. The local `llm` canister runs in `https` mode and needs an
+  [Internet Intelligence Gateway](https://inference.internetcomputer.org/) API
+  key to serve prompts.
 
-> **Note**: When developing locally, the architecture differs slightly from mainnet. Instead of using AI workers, the LLM canister connects directly to your local Ollama instance. This makes local development faster and easier, while still maintaining the same interface and behavior as the mainnet deployment. For more information about how the LLM canister works, see the [How Does it Work?](../README.md#how-does-it-work).
-
-Before using this library in local development, you need to set up the LLM canister dependency:
-
-### Prerequisites
-- [DFX](https://internetcomputer.org/docs/building-apps/getting-started/install) installed
-- [Ollama](https://ollama.com/) installed and running locally
-
-### Setup Steps
-
-1. **Start Ollama** (required for local development):
-```bash
-# Start the Ollama server
-ollama serve
-
-# Download the required model (one-time setup)
-ollama run llama3.1:8b
-```
-
-2. **Add LLM canister to your dfx.json** (Note: This only works for dfx <=0.25.0):
-```json
-{
-  "canisters": {
-    "llm": {
-      "type": "pull",
-      "id": "w36hm-eqaaa-aaaal-qr76a-cai"
-    },
-    "your-canister": {
-      "dependencies": ["llm"],
-      "type": "motoko"
-    }
-  }
-}
-```
-
-Alternatively you can also define the llm dependency like this:
-```json
-    "llm": {
-      "candid": "https://github.com/dfinity/llm/releases/latest/download/llm-canister-ollama.did",
-      "type": "custom",
-      "specified_id": "w36hm-eqaaa-aaaal-qr76a-cai",
-      "remote": {
-        "id": {
-          "ic": "w36hm-eqaaa-aaaal-qr76a-cai"
-        }
-      },
-```
-
-3. **Deploy locally**:
-```bash
-dfx start --clean
-dfx deps pull
-dfx deps deploy
-dfx deploy
-```
+See the [quickstart example](../examples/quickstart-agent-motoko) for a complete
+project — `icp.yaml`, deploying locally, and calling the agent.
 
 ## Install
 
@@ -100,191 +45,18 @@ The simplest way to interact with a model is by sending a single prompt:
 ```motoko
 import LLM "mo:llm";
 
-actor {
-  public func prompt(prompt : Text) : async Text {
-    await LLM.prompt("llama3.1:8b", prompt);
-  };
-}
+let answer = await LLM.prompt("llama3.1:8b", "Write a haiku about the Internet Computer.");
 ```
 
 ### Chatting (multiple messages)
 
-For more complex interactions, you can send multiple messages in a conversation:
+For more complex interactions, send multiple messages in a conversation:
 
 ```motoko
 import LLM "mo:llm";
 
-actor {
-  public func example() {
-    let response = await LLM.chat("llama3.1:8b").withMessages([
-      #system_ {
-        content = "You are a helpful assistant.";
-      },
-      #user {
-        content = "How big is the sun?";
-      },
-    ]).send();
-  };
-}
-```
-
-### Advanced Usage with Tools
-
-#### Understanding Tools
-
-**Tools** are custom functions that you define and make available to the LLM. They allow the AI to perform actions beyond just generating text responses. When you provide tools to the LLM, it can decide when and how to use them based on the user's request.
-
-**Common use cases for tools:**
-- **Data retrieval**: Fetching real-time information (prices, weather, account balances)
-- **External API calls**: Integrating with third-party services
-- **Calculations**: Performing complex computations
-- **Database operations**: Querying or updating data
-- **Custom business logic**: Executing domain-specific functions
-
-**How it works:**
-1. You define available tools with their parameters
-2. The LLM analyzes the user's request
-3. If a tool would be helpful, the LLM returns a "tool call" instead of a direct answer
-4. Your code executes the requested tool with the LLM's provided parameters
-5. You send the tool's result back to the LLM
-6. The LLM incorporates the result into its final response
-
-#### Defining and Using a Tool
-
-You can define tools that the LLM can use to perform actions:
-
-```motoko
-import LLM "mo:llm";
-
-actor {
-  public func example() {
-    let response = await LLM.chat("llama3.1:8b")
-      .withMessages([
-        #system_ {
-          content = "You are a helpful assistant."
-        },
-        #user {
-          content = "What's the weather in San Francisco?"
-        },
-      ])
-      .withTools([LLM.tool("get_weather")
-        .withDescription("Get current weather for a location")
-        .withParameter(
-          LLM.parameter("location", #String)
-            .withDescription("The location to get weather for")
-            .isRequired()
-        )
-        .build()
-      ])
-      .send();
-  };
-}
-```
-
-#### Handling Tool Calls from the LLM
-
-When the LLM decides to use one of your tools, you need to handle the tool call and provide the result:
-
-```motoko
-import LLM "mo:llm";
-import Debug "mo:base/Debug";
-
-actor {
-  public func handleChat(userMessage : Text) : async Text {
-    let response = await LLM.chat("llama3.1:8b")
-      .withMessages([
-        #system_ {
-          content = "You are a helpful assistant."
-        },
-        #user {
-          content = userMessage
-        },
-      ])
-      .withTools([
-        LLM.tool("get_weather")
-          .withDescription("Get current weather for a location")
-          .withParameter(
-            LLM.parameter("location", #String)
-              .withDescription("The location to get weather for")
-              .isRequired()
-          )
-          .build(),
-        LLM.tool("get_icp_price")
-          .withDescription("Get the current ICP token price")
-          .build()
-      ])
-      .send();
-    
-    // Check if the LLM wants to use any tools
-    switch (response.message.tool_calls.size()) {
-      case (0) {
-        // No tool calls - LLM provided a direct response
-        switch (response.message.content) {
-          case (?content) { content };
-          case null { "No response received" };
-        }
-      };
-      case (_) {
-        // Process tool calls
-        var toolResults : [LLM.ChatMessage] = [];
-        
-        for (toolCall in response.message.tool_calls.vals()) {
-          let result = switch (toolCall.function.name) {
-            case ("get_weather") {
-              let location = getToolParameter(toolCall.function.arguments, "location");
-              await getWeather(location)
-            };
-            case ("get_icp_price") {
-              await getIcpPrice()
-            };
-            case (_) {
-              "Unknown tool: " # toolCall.function.name
-            };
-          };
-          
-          // Add tool result to conversation
-          toolResults := Array.append(toolResults, [#tool {
-            content = result;
-            tool_call_id = toolCall.id;
-          }]);
-        };
-        
-        // Send tool results back to LLM for final response
-        let finalResponse = await LLM.chat("llama3.1:8b")
-          .withMessages(Array.append([
-            #system_ { content = "You are a helpful assistant." },
-            #user { content = userMessage },
-            #assistant(response.message)
-          ], toolResults))
-          .send();
-          
-        switch (finalResponse.message.content) {
-          case (?content) { content };
-          case null { "No final response received" };
-        }
-      };
-    }
-  };
-
-  // Helper function to extract parameter values
-  private func getToolParameter(arguments : [LLM.ToolCallArgument], paramName : Text) : Text {
-    for (arg in arguments.vals()) {
-      if (arg.name == paramName) {
-        return arg.value;
-      };
-    };
-    ""
-  };
-
-  // Example tool implementations
-  private func getWeather(location : Text) : async Text {
-    // In a real implementation, you would call a weather API
-    "Weather in " # location # ": Sunny, 72°F"
-  };
-
-  private func getIcpPrice() : async Text {
-    // In a real implementation, you would call a price API
-    "Current ICP price: $10.50"
-  };
-}
+let response = await LLM.chat("llama3.1:8b").withMessages([
+  #system_ { content = "You are a helpful assistant for Internet Computer developers." },
+  #user { content = "Suggest a fun name for my new canister." },
+]).send();
 ```

--- a/motoko/mops.toml
+++ b/motoko/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm"
-version = "3.0.0"
+version = "3.1.0"
 description = "Library for the LLM canister"
 repository = "https://github.com/dfinity/llm/motoko"
 keywords = [ "llm", "ai", "agent" ]

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -1,20 +1,45 @@
+import Prim "mo:⛔";
 import Tool "./tool";
 
 module {
-    private let llmCanister = actor ("w36hm-eqaaa-aaaal-qr76a-cai") : actor {
+    /// The mainnet principal of the LLM canister.
+    let MAINNET_LLM_CANISTER = "w36hm-eqaaa-aaaal-qr76a-cai";
+
+    type LlmCanister = actor {
         v1_chat : (Request) -> async Response;
     };
 
-    /// Cycles attached to every `v1_chat` call.
+    /// Resolves the LLM canister to call.
     ///
-    /// Paid models require a minimum of 100B cycles to accept a request. Free
-    /// models charge nothing: they accept no cycles and the full amount is
-    /// refunded. Paid models accept only what's needed to cover the request and
-    /// refund the remainder, so attaching this amount unconditionally is safe.
+    /// Prefers the `PUBLIC_CANISTER_ID:llm` environment variable (auto-injected
+    /// by `icp deploy` so the library targets the local `llm` canister during
+    /// development) and otherwise falls back to the mainnet canister.
+    func llmCanister<system>() : LlmCanister {
+        let id = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:llm")) {
+            case (?principal) principal;
+            case null MAINNET_LLM_CANISTER;
+        };
+        actor (id) : LlmCanister;
+    };
+
+    /// Cycles attached to a `v1_chat` call for a paid model.
     ///
-    /// Note: the calling canister must hold at least this many cycles when
-    /// `send()` runs, otherwise the call traps.
+    /// Paid models require a minimum of 100B cycles to accept a request; they
+    /// charge only what the request costs and refund the remainder. Free models
+    /// accept no cycles, so we attach none — see `FREE_MODELS`.
     let CYCLES_PER_CHAT : Nat = 100_000_000_000;
+
+    /// Models that are free to call. Requests to these attach no cycles, so the
+    /// calling canister doesn't need to hold any. Every other model is treated
+    /// as paid and gets `CYCLES_PER_CHAT` attached.
+    let FREE_MODELS = ["llama3.1:8b", "qwen3:32b"];
+
+    func isFreeModel(model : Text) : Bool {
+        for (freeModel in FREE_MODELS.vals()) {
+            if (freeModel == model) return true;
+        };
+        false;
+    };
 
     /// A message in a chat.
     public type ChatMessage = {
@@ -78,12 +103,13 @@ module {
 
         /// Sends the chat request to the LLM canister.
         ///
-        /// Attaches `CYCLES_PER_CHAT` cycles to pay for paid models. Free models
-        /// refund the full amount. The calling canister must hold at least that
-        /// many cycles or this call traps.
+        /// Paid models get `CYCLES_PER_CHAT` cycles attached (the calling
+        /// canister must hold at least that many or this call traps); free
+        /// models get none.
         public func send() : async Response {
             let request = build();
-            await (with cycles = CYCLES_PER_CHAT) llmCanister.v1_chat(request)
+            let cyclesToAttach = if (isFreeModel(_model)) 0 else CYCLES_PER_CHAT;
+            await (with cycles = cyclesToAttach) llmCanister<system>().v1_chat(request)
         };
     };
 };


### PR DESCRIPTION
Library-only changes to `mo:llm` (bumped to **3.1.0**). The `quickstart-agent-motoko` migration to icp-cli will follow in a separate PR.

## Changes

- **Configurable LLM canister.** Drops the module-level hardcoded actor binding to `w36hm-…`. `chat.mo` now resolves the canister at `send()` time from the `PUBLIC_CANISTER_ID:llm` environment variable that `icp deploy` injects, falling back to the mainnet canister. This lets the library target a locally-deployed `llm` canister with no code changes between environments — necessary since `icp-cli` no longer supports specified canister IDs. `send()` keeps its signature; the `<system>` capability is supplied implicitly from its `async` body, so existing callers are unaffected.

- **Cycles only for paid models.** Free models (`llama3.1:8b`, `qwen3:32b`) are now called with no cycles attached, so the calling canister needn't hold any. All other models get 100B cycles attached (charged as needed, remainder refunded).

- **README rewrite.** Documents the icp-cli + Internet Intelligence Gateway flow; removes the outdated dfx/Ollama setup instructions and the untested tool-handling section.

Verified with `mops test` and a local `icp deploy` end-to-end (free-model call succeeds with no cycles attached, resolving the local `llm` canister via the injected env var).

Refs: DEFI-2832
