### PR TITLE
feat(motoko): support v1.1.0 llm canister with paid models (3.0.0)

### DIFF
--- a/motoko/.gitignore
+++ b/motoko/.gitignore
@@ -1,1 +1,2 @@
 .mops
+mops.lock

--- a/motoko/README.md
+++ b/motoko/README.md
@@ -4,11 +4,28 @@ A library for making requests to the LLM canister on the Internet Computer.
 
 ## Supported Models
 
-The following LLM models are available:
+Models are identified by their string name (passed to `LLM.prompt` and
+`LLM.chat`). The available models are:
 
-- `#Llama3_1_8B` - Llama 3.1 8B model
-- `#Qwen3_32B` - Qwen 3 32B model
-- `#Llama4Scout` - Llama 4 Scout model
+| Model string      | Pricing |
+| ----------------- | ------- |
+| `"llama3.1:8b"`   | Free    |
+| `"qwen3:32b"`     | Free    |
+| `"llama4-scout"`  | Free    |
+| `"qwen2.5:0.5b"`  | Free    |
+| `"gemma3:27b"`    | Paid    |
+| `"z-ai:glm-5.2"`  | Paid    |
+
+Models are added frequently — see the [LLM canister](../README.md) for the
+authoritative, up-to-date list.
+
+### Paying for models
+
+`send()` automatically attaches 100B cycles to every request. Paid models are
+charged from those cycles (any unused portion is refunded); free models refund
+the full amount. Because cycles are always attached, **the calling canister must
+hold at least 100B cycles when `send()` runs, or the call traps** — this applies
+even when using a free model.
 
 ## Local Development Setup
 
@@ -85,7 +102,7 @@ import LLM "mo:llm";
 
 actor {
   public func prompt(prompt : Text) : async Text {
-    await LLM.prompt(#Llama3_1_8B, prompt);
+    await LLM.prompt("llama3.1:8b", prompt);
   };
 }
 ```
@@ -99,7 +116,7 @@ import LLM "mo:llm";
 
 actor {
   public func example() {
-    let response = await LLM.chat(#Llama3_1_8B).withMessages([
+    let response = await LLM.chat("llama3.1:8b").withMessages([
       #system_ {
         content = "You are a helpful assistant.";
       },
@@ -143,7 +160,7 @@ import LLM "mo:llm";
 
 actor {
   public func example() {
-    let response = await LLM.chat(#Llama3_1_8B)
+    let response = await LLM.chat("llama3.1:8b")
       .withMessages([
         #system_ {
           content = "You are a helpful assistant."
@@ -176,7 +193,7 @@ import Debug "mo:base/Debug";
 
 actor {
   public func handleChat(userMessage : Text) : async Text {
-    let response = await LLM.chat(#Llama3_1_8B)
+    let response = await LLM.chat("llama3.1:8b")
       .withMessages([
         #system_ {
           content = "You are a helpful assistant."
@@ -235,7 +252,7 @@ actor {
         };
         
         // Send tool results back to LLM for final response
-        let finalResponse = await LLM.chat(#Llama3_1_8B)
+        let finalResponse = await LLM.chat("llama3.1:8b")
           .withMessages(Array.append([
             #system_ { content = "You are a helpful assistant." },
             #user { content = userMessage },

--- a/motoko/mops.toml
+++ b/motoko/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm"
-version = "2.1.0"
+version = "3.0.0"
 description = "Library for the LLM canister"
 repository = "https://github.com/dfinity/llm/motoko"
 keywords = [ "llm", "ai", "agent" ]
@@ -11,3 +11,6 @@ base = "0.14.9"
 
 [dev-dependencies]
 test = "2.1.1"
+
+[toolchain]
+moc = "1.8.2"

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -5,6 +5,17 @@ module {
         v1_chat : (Request) -> async Response;
     };
 
+    /// Cycles attached to every `v1_chat` call.
+    ///
+    /// Paid models require a minimum of 100B cycles to accept a request. Free
+    /// models charge nothing: they accept no cycles and the full amount is
+    /// refunded. Paid models accept only what's needed to cover the request and
+    /// refund the remainder, so attaching this amount unconditionally is safe.
+    ///
+    /// Note: the calling canister must hold at least this many cycles when
+    /// `send()` runs, otherwise the call traps.
+    let CYCLES_PER_CHAT : Nat = 100_000_000_000;
+
     /// A message in a chat.
     public type ChatMessage = {
         #user : { content : Text };
@@ -29,24 +40,12 @@ module {
         tools : ?[Tool.Tool];
     };
 
-    /// Supported LLM models
-    public type Model = {
-        #Llama3_1_8B;
-        #Qwen3_32B;
-        #Llama4Scout;
-    };
-
-    public func modelToText(model : Model) : Text {
-        switch (model) {
-            case (#Llama3_1_8B) { "llama3.1:8b" };
-            case (#Qwen3_32B) { "qwen3:32b" };
-            case (#Llama4Scout) { "llama4-scout" };
-        };
-    };
-
     /// Builder for creating and sending chat requests to the LLM canister.
-    public class ChatBuilder(model : Model) = self {
-        private var _model : Model = model;
+    ///
+    /// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free)
+    /// or `"gemma3:27b"` (paid). See the README for the current list.
+    public class ChatBuilder(model : Text) = self {
+        private var _model : Text = model;
         private var _messages : [ChatMessage] = [];
         private var _tools : [Tool.Tool] = [];
 
@@ -71,16 +70,20 @@ module {
             };
 
             {
-                model = modelToText(_model);
+                model = _model;
                 messages = _messages;
                 tools = tools_option;
             }
         };
 
         /// Sends the chat request to the LLM canister.
+        ///
+        /// Attaches `CYCLES_PER_CHAT` cycles to pay for paid models. Free models
+        /// refund the full amount. The calling canister must hold at least that
+        /// many cycles or this call traps.
         public func send() : async Response {
             let request = build();
-            await llmCanister.v1_chat(request)
+            await (with cycles = CYCLES_PER_CHAT) llmCanister.v1_chat(request)
         };
     };
 };

--- a/motoko/src/lib.mo
+++ b/motoko/src/lib.mo
@@ -8,10 +8,9 @@ module {
   public type AssistantMessage = Chat.AssistantMessage;
   public type Response = Chat.Response;
   public type Request = Chat.Request;
-  public type Model = Chat.Model;
-  
 
-  public func prompt(model : Chat.Model, promptStr : Text) : async Text {
+
+  public func prompt(model : Text, promptStr : Text) : async Text {
     let response = await Chat.ChatBuilder(model).withMessages([
       #user({
         content = promptStr;
@@ -24,7 +23,7 @@ module {
     };
   };
 
-  public func chat(model : Chat.Model) : Chat.ChatBuilder {
+  public func chat(model : Text) : Chat.ChatBuilder {
     Chat.ChatBuilder(model);
   };
 

--- a/motoko/test/chat.test.mo
+++ b/motoko/test/chat.test.mo
@@ -5,7 +5,7 @@ import { test } "mo:test";
 test(
     "create chat builder",
     func() {
-        let builder = Chat.ChatBuilder(#Llama3_1_8B);
+        let builder = Chat.ChatBuilder("llama3.1:8b");
 
         let request = builder.build();
         assert request == {
@@ -24,7 +24,7 @@ test(
             #user { content = "Hello" },
         ];
 
-        let builder = Chat.ChatBuilder(#Llama3_1_8B).withMessages(messages);
+        let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages);
         
         let request = builder.build();
         assert request == {
@@ -42,7 +42,7 @@ test(
             .withDescription("A test tool")
             .build();
 
-        let builder = Chat.ChatBuilder(#Llama3_1_8B).withTools([tool]);
+        let builder = Chat.ChatBuilder("llama3.1:8b").withTools([tool]);
         
         let request = builder.build();
         assert request == {
@@ -62,7 +62,7 @@ test(
 
         let tool = (Tool.ToolBuilder("test_tool")).build();
 
-        let builder = Chat.ChatBuilder(#Llama3_1_8B)
+        let builder = Chat.ChatBuilder("llama3.1:8b")
             .withMessages(messages)
             .withTools([tool]);
             
@@ -97,10 +97,3 @@ test(
         assert Tool.getArgument(function_call, "arg3") == null;
     },
 );
-
-test(
-    "model to text conversion",
-    func() {
-        assert Chat.modelToText(#Llama3_1_8B) == "llama3.1:8b";
-    },
-); 


### PR DESCRIPTION
Upgrades the Motoko `mo:llm` library to **3.0.0**, targeting the v1.1.0 llm canister which introduces paid models charged in cycles. Library-only change; examples are untouched.

## Changes

- **Cycles for paid models.** `send()` now attaches **100B cycles** to every `v1_chat` call. Paid models are billed from these cycles (any unused portion is refunded); free models refund the full amount. Because cycles are always attached, the calling canister must hold at least 100B cycles when `send()` runs — this applies even for free models.
- **Models are plain strings.** `LLM.chat` / `LLM.prompt` now take a model identifier as `Text` (e.g. `"llama3.1:8b"`, `"gemma3:27b"`) instead of the `Model` variant. Models are added frequently, so this lets consumers use new models without waiting for a library release. The `Model` type and `modelToText` are removed.
- **Tooling / docs.** Pin the `moc` toolchain in `mops.toml`, ignore `mops.lock`, and refresh the README (model table with free/paid pricing + a section on cycle attachment).

## Breaking changes

- `LLM.chat(model)` / `LLM.prompt(model, ...)` take a `Text` model name instead of a `#Llama3_1_8B`-style variant.
- The `Model` type (and `modelToText`) are removed.

Migration:

```motoko
// before
LLM.chat(#Llama3_1_8B)
// after
LLM.chat("llama3.1:8b")
```

## Testing

- `mops test` passes.
- Verified the backend compiles and links against the new API by building a consumer actor to wasm, and confirmed the cycle-attaching `send()` works end-to-end against a locally deployed v1.1.0 llm canister (https runtime).

Refs: DEFI-2832