### PR TITLE
feat(rust): support v1.1.0 llm canister with paid models (2.0.0)

### DIFF
--- a/examples/quickstart-agent-rust/Cargo.lock
+++ b/examples/quickstart-agent-rust/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "ic-llm"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "candid",
  "ic-cdk",

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -13,22 +13,22 @@ the IC.
 - Run `pnpm install` at the repo root once — that brings in
   [`icp-cli`](https://github.com/dfinity/icp-cli) and `ic-wasm` as project
   devDependencies, exposed on PATH via mise's `_.path` config.
-- One of the two LLM backends below: by default the local `llm` canister
-  uses [Ollama](https://ollama.com/) (free, runs on your machine). If you'd
-  rather use [OpenRouter](https://openrouter.ai/) (a paid cloud service that
-  can host larger models), see [LLM backend selection](#llm-backend-selection)
-  for how to switch.
+- An API key for the Internet Intelligence Gateway — see
+  [Getting an API key](#getting-an-api-key). The local `llm` canister uses it
+  to serve prompts.
 
-## Quickstart with Ollama
+## Quickstart
+
+Add your API key to the `llm` canister's `init_args` in `icp.yaml`
+(see [Getting an API key](#getting-an-api-key)):
+
+```yaml
+init_args: '(opt variant { https = record { api_key = "YOUR_API_KEY" } })'
+```
+
+Then start the local replica and deploy everything:
 
 ```bash
-# Start Ollama (one window).
-ollama serve
-
-# Pull the model (one-time).
-ollama run llama3.1:8b
-
-# Start the local replica and deploy everything (separate window).
 icp network start -d
 icp deploy
 ```
@@ -36,29 +36,22 @@ icp deploy
 The frontend URL is printed at the end of `icp deploy`. Open it in a browser
 (use the `*.localhost:8080` form to avoid CORS issues).
 
-## LLM backend selection
+## Getting an API key
 
-The on-chain `llm` canister has two backends:
+The local `llm` canister runs in `https` mode: it serves prompts by making
+HTTPS outcalls to the Internet Intelligence Gateway, authenticated with an API
+key. To get a key:
 
-1. **Ollama** (local, free) — the default. Suitable for development.
-2. **OpenRouter** (cloud, paid) — needed for larger models. Requires an
-   [API key](https://openrouter.ai/settings/keys).
+1. Sign up at https://inference.internetcomputer.org/beta.
 
-The choice is encoded in `icp.yaml`'s `init_args` for the `llm` canister. To
-switch from the default Ollama setup to OpenRouter, edit `icp.yaml`:
+Put the key in the `llm` canister's `init_args` in `icp.yaml`:
 
 ```yaml
-canisters:
-  - name: llm
-    build:
-      steps:
-        - type: pre-built
-          url: https://github.com/dfinity/llm/releases/download/v0.3.1/llm-canister.wasm
-          sha256: 9fc6a172b13289428c6975895382c3c923fb641bcd8e8a5168469298c3cff310
-    init_args: '(opt variant { openrouter = record { api_key = "YOUR_API_KEY" } }, null)'
+init_args: '(opt variant { https = record { api_key = "YOUR_API_KEY" } })'
 ```
 
-Then reinstall the `llm` canister so the new init args take effect:
+If you change the key after the first deploy, reinstall the `llm` canister so
+the new init args take effect:
 
 ```bash
 icp deploy llm --mode reinstall

--- a/examples/quickstart-agent-rust/README.md
+++ b/examples/quickstart-agent-rust/README.md
@@ -23,7 +23,7 @@ Add your API key to the `llm` canister's `init_args` in `icp.yaml`
 (see [Getting an API key](#getting-an-api-key)):
 
 ```yaml
-init_args: '(opt variant { https = record { api_key = "YOUR_API_KEY" } })'
+init_args: '(opt variant { https = record { api_key = "<YOUR_IIG_API_KEY>" } })'
 ```
 
 Then start the local replica and deploy everything:

--- a/examples/quickstart-agent-rust/icp.yaml
+++ b/examples/quickstart-agent-rust/icp.yaml
@@ -5,9 +5,9 @@ canisters:
     build:
       steps:
         - type: pre-built
-          url: https://github.com/dfinity/llm/releases/download/v0.3.1/llm-canister.wasm
-          sha256: 9fc6a172b13289428c6975895382c3c923fb641bcd8e8a5168469298c3cff310
-    init_args: "(opt variant { ollama }, null)"
+          url: https://github.com/dfinity/llm/releases/download/v1.1.0/llm-canister.wasm
+          sha256: c09c3bbb33a1a60bad432e697684d109180d8272ea0a909fd511129c2ca178c5
+    init_args: "(opt variant { https = record { api_key = \"<YOUR_IIG_API_KEY>\" } })"
 
   - name: agent-backend
     recipe:

--- a/examples/quickstart-agent-rust/src/backend/src/lib.rs
+++ b/examples/quickstart-agent-rust/src/backend/src/lib.rs
@@ -1,13 +1,13 @@
-use ic_llm::{ChatMessage, Model};
+use ic_llm::ChatMessage;
 
 #[ic_cdk::update]
 async fn prompt(prompt_str: String) -> String {
-    ic_llm::prompt(Model::Llama3_1_8B, prompt_str).await
+    ic_llm::prompt("llama3.1:8b", prompt_str).await
 }
 
 #[ic_cdk::update]
 async fn chat(messages: Vec<ChatMessage>) -> String {
-    let response = ic_llm::chat(Model::Llama3_1_8B)
+    let response = ic_llm::chat("llama3.1:8b")
         .with_messages(messages)
         .send()
         .await;

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "ic-llm"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "candid",
  "ic-cdk",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-llm"
-version = "1.2.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.94"
 description = "A library for making requests to the LLM canister on the Internet Computer"

--- a/rust/README.md
+++ b/rust/README.md
@@ -5,11 +5,28 @@ A library for making requests to the LLM canister on the Internet Computer.
 
 ## Supported Models
 
-The following LLM models are available:
+Models are identified by their string name (passed to `ic_llm::prompt` and
+`ic_llm::chat`). The available models are:
 
-- `Model::Llama3_1_8B` - Llama 3.1 8B model
-- `Model::Qwen3_32B` - Qwen 3 32B model  
-- `Model::Llama4Scout` - Llama 4 Scout model
+| Model string      | Pricing |
+| ----------------- | ------- |
+| `"llama3.1:8b"`   | Free    |
+| `"qwen3:32b"`     | Free    |
+| `"llama4-scout"`  | Free    |
+| `"qwen2.5:0.5b"`  | Free    |
+| `"gemma3:27b"`    | Paid    |
+| `"z-ai:glm-5.2"`  | Paid    |
+
+Models are added frequently — see the [LLM canister](../README.md) for the
+authoritative, up-to-date list.
+
+### Paying for models
+
+`send()` automatically attaches 100B cycles to every request. Paid models are
+charged from those cycles (any unused portion is refunded); free models refund
+the full amount. Because cycles are always attached, **the calling canister must
+hold at least 100B cycles when `send()` runs, or the call traps** — this applies
+even when using a free model.
 
 ## Local Development
 
@@ -39,10 +56,8 @@ locally — see the examples in this repository (e.g.
 The simplest way to interact with a model is by sending a single prompt:
 
 ```rust
-use ic_llm::Model;
-
 async fn example() -> String {
-    ic_llm::prompt(Model::Llama3_1_8B, "What's the speed of light?").await
+    ic_llm::prompt("llama3.1:8b", "What's the speed of light?").await
 }
 ```
 
@@ -51,10 +66,10 @@ async fn example() -> String {
 For more complex interactions, you can send multiple messages in a conversation:
 
 ```rust
-use ic_llm::{Model, ChatMessage};
+use ic_llm::ChatMessage;
 
 async fn example() {
-    ic_llm::chat(Model::Llama3_1_8B)
+    ic_llm::chat("llama3.1:8b")
         .with_messages(vec![
             ChatMessage::System {
                 content: "You are a helpful assistant".to_string(),
@@ -81,11 +96,9 @@ override the canister explicitly:
 
 ```rust
 use candid::Principal;
-use ic_llm::Model;
-
 async fn example() {
     let custom = Principal::from_text("aaaaa-aa").unwrap();
-    ic_llm::chat(Model::Llama3_1_8B)
+    ic_llm::chat("llama3.1:8b")
         .with_canister(custom)
         .with_messages(vec![])
         .send()
@@ -123,10 +136,10 @@ When you provide tools to the LLM, it can decide when and how to use them based 
 You can define tools that the LLM can use to perform actions:
 
 ```rust
-use ic_llm::{Model, ChatMessage, ParameterType};
+use ic_llm::{ChatMessage, ParameterType};
 
 async fn example() {
-    ic_llm::chat(Model::Llama3_1_8B)
+    ic_llm::chat("llama3.1:8b")
         .with_messages(vec![
             ChatMessage::System {
                 content: "You are a helpful assistant".to_string(),
@@ -155,10 +168,10 @@ async fn example() {
 When the LLM decides to use one of your tools, you can handle the call:
 
 ```rust
-use ic_llm::{Model, ChatMessage, ParameterType, Response};
+use ic_llm::{ChatMessage, ParameterType, Response};
 
 async fn example() -> Response {
-    let response = ic_llm::chat(Model::Llama3_1_8B)
+    let response = ic_llm::chat("llama3.1:8b")
         .with_messages(vec![
             ChatMessage::System {
                 content: "You are a helpful assistant".to_string(),
@@ -208,7 +221,7 @@ async fn get_weather(location: &str) -> String {
 Here's a more complete example showing how to handle tool calls and continue the conversation:
 
 ```rust
-use ic_llm::{Model, ChatMessage, ParameterType, Response};
+use ic_llm::{ChatMessage, ParameterType, Response};
 
 async fn handle_chat_with_tools(user_message: String) -> String {
     let mut messages = vec![
@@ -234,7 +247,7 @@ async fn handle_chat_with_tools(user_message: String) -> String {
             .build()
     ];
 
-    let response = ic_llm::chat(Model::Llama3_1_8B)
+    let response = ic_llm::chat("llama3.1:8b")
         .with_messages(messages.clone())
         .with_tools(tools)
         .send()
@@ -266,7 +279,7 @@ async fn handle_chat_with_tools(user_message: String) -> String {
         }
 
         // Get final response from LLM with tool results
-        let final_response = ic_llm::chat(Model::Llama3_1_8B)
+        let final_response = ic_llm::chat("llama3.1:8b")
             .with_messages(messages)
             .send()
             .await;

--- a/rust/src/chat.rs
+++ b/rust/src/chat.rs
@@ -65,10 +65,21 @@ struct Request {
     tools: Option<Vec<Tool>>,
 }
 
+/// Cycles attached to every `v1_chat` call.
+///
+/// Paid models require a minimum of 100B cycles to accept a request. Free
+/// models charge nothing: they accept no cycles and the full amount is
+/// refunded. Paid models accept only what's needed to cover the request and
+/// refund the remainder, so attaching this amount unconditionally is safe.
+///
+/// Note: the calling canister must hold at least this many cycles when `send()`
+/// runs, otherwise the call traps.
+const CYCLES_PER_CHAT: u128 = 100_000_000_000;
+
 /// Builder for creating and sending chat requests to the LLM canister.
 #[derive(Debug)]
 pub struct ChatBuilder {
-    model: crate::Model,
+    model: String,
     messages: Vec<ChatMessage>,
     tools: Vec<Tool>,
     canister: Principal,
@@ -76,9 +87,12 @@ pub struct ChatBuilder {
 
 impl ChatBuilder {
     /// Creates a new chat builder with a model.
-    pub fn new(model: crate::Model) -> Self {
+    ///
+    /// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free)
+    /// or `"gemma3:27b"` (paid). See the README for the current list.
+    pub fn new(model: impl Into<String>) -> Self {
         Self {
-            model,
+            model: model.into(),
             messages: Vec::new(),
             tools: Vec::new(),
             canister: crate::default_llm_canister(),
@@ -111,6 +125,10 @@ impl ChatBuilder {
     }
 
     /// Sends the chat request to the LLM canister.
+    ///
+    /// Attaches `CYCLES_PER_CHAT` cycles to pay for paid models. Free models
+    /// refund the full amount. The calling canister must hold at least that
+    /// many cycles or this call traps.
     pub async fn send(self) -> Response {
         let tools_option = if self.tools.is_empty() {
             None
@@ -120,8 +138,9 @@ impl ChatBuilder {
 
         ic_cdk::call::Call::bounded_wait(self.canister, "v1_chat")
             .change_timeout(300)
+            .with_cycles(CYCLES_PER_CHAT)
             .with_arg(Request {
-                model: self.model.to_string(),
+                model: self.model,
                 messages: self.messages,
                 tools: tools_option,
             })
@@ -136,11 +155,10 @@ impl ChatBuilder {
 mod tests {
     use super::*;
     use crate::tool::ToolBuilder;
-    use crate::Model;
 
     #[test]
     fn create_chat_builder() {
-        let builder = ChatBuilder::new(Model::Llama3_1_8B);
+        let builder = ChatBuilder::new("llama3.1:8b");
         assert!(builder.messages.is_empty());
         assert!(builder.tools.is_empty());
     }
@@ -156,7 +174,7 @@ mod tests {
             },
         ];
 
-        let builder = ChatBuilder::new(Model::Llama3_1_8B).with_messages(messages.clone());
+        let builder = ChatBuilder::new("llama3.1:8b").with_messages(messages.clone());
 
         assert_eq!(builder.messages, messages);
         assert!(builder.tools.is_empty());
@@ -168,7 +186,7 @@ mod tests {
             .with_description("A test tool")
             .build();
 
-        let builder = ChatBuilder::new(Model::Llama3_1_8B).with_tools(vec![tool.clone()]);
+        let builder = ChatBuilder::new("llama3.1:8b").with_tools(vec![tool.clone()]);
 
         assert!(builder.messages.is_empty());
         assert_eq!(builder.tools.len(), 1);
@@ -177,7 +195,7 @@ mod tests {
 
     #[test]
     fn chat_builder_defaults_to_mainnet_llm_canister() {
-        let builder = ChatBuilder::new(Model::Llama3_1_8B);
+        let builder = ChatBuilder::new("llama3.1:8b");
         assert_eq!(
             builder.canister,
             Principal::from_text(crate::MAINNET_LLM_CANISTER).unwrap(),
@@ -187,7 +205,7 @@ mod tests {
     #[test]
     fn chat_builder_with_canister() {
         let canister = Principal::from_slice(&[1, 2, 3, 4]);
-        let builder = ChatBuilder::new(Model::Llama3_1_8B).with_canister(canister);
+        let builder = ChatBuilder::new("llama3.1:8b").with_canister(canister);
         assert_eq!(builder.canister, canister);
     }
 
@@ -199,7 +217,7 @@ mod tests {
 
         let tool = ToolBuilder::new("test_tool").build();
 
-        let builder = ChatBuilder::new(Model::Llama3_1_8B)
+        let builder = ChatBuilder::new("llama3.1:8b")
             .with_messages(messages.clone())
             .with_tools(vec![tool.clone()]);
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 use candid::Principal;
-use std::fmt;
 
 // Define our modules
 mod chat;
@@ -32,37 +31,19 @@ pub(crate) fn default_llm_canister() -> Principal {
     Principal::from_text(MAINNET_LLM_CANISTER).unwrap()
 }
 
-/// Supported LLM models.
-#[derive(Debug)]
-pub enum Model {
-    Llama3_1_8B,
-    Qwen3_32B,
-    Llama4Scout,
-}
-
-impl fmt::Display for Model {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let text = match self {
-            Model::Llama3_1_8B => "llama3.1:8b",
-            Model::Qwen3_32B => "qwen3:32b",
-            Model::Llama4Scout => "llama4-scout",
-        };
-        write!(f, "{}", text)
-    }
-}
-
 /// Sends a single message to a model.
+///
+/// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free) or
+/// `"gemma3:27b"` (paid). See the README for the current list.
 ///
 /// # Example
 ///
 /// ```
-/// use ic_llm::Model;
-///
 /// # async fn prompt_example() -> String {
-/// ic_llm::prompt(Model::Llama3_1_8B, "What's the speed of light?").await
+/// ic_llm::prompt("llama3.1:8b", "What's the speed of light?").await
 /// # }
 /// ```
-pub async fn prompt<P: ToString>(model: Model, prompt_str: P) -> String {
+pub async fn prompt<P: ToString>(model: impl Into<String>, prompt_str: P) -> String {
     let response = ChatBuilder::new(model)
         .with_messages(vec![ChatMessage::User {
             content: prompt_str.to_string(),
@@ -81,11 +62,11 @@ pub async fn prompt<P: ToString>(model: Model, prompt_str: P) -> String {
 /// # Example
 ///
 /// ```
-/// use ic_llm::{Model, ChatMessage, Response};
+/// use ic_llm::{ChatMessage, Response};
 ///
 /// # async fn chat_example() -> Response {
 /// // Basic usage
-/// ic_llm::chat(Model::Llama3_1_8B)
+/// ic_llm::chat("llama3.1:8b")
 ///     .with_messages(vec![
 ///         ChatMessage::System {
 ///             content: "You are a helpful assistant".to_string(),
@@ -102,10 +83,10 @@ pub async fn prompt<P: ToString>(model: Model, prompt_str: P) -> String {
 /// You can also add tools to the chat:
 ///
 /// ```
-/// use ic_llm::{Model, ChatMessage, ParameterType, Response};
+/// use ic_llm::{ChatMessage, ParameterType, Response};
 ///
 /// # async fn chat_with_tools_example() -> Response {
-/// ic_llm::chat(Model::Llama3_1_8B)
+/// ic_llm::chat("llama3.1:8b")
 ///     .with_messages(vec![
 ///         ChatMessage::System {
 ///             content: "You are a helpful assistant".to_string(),
@@ -128,7 +109,7 @@ pub async fn prompt<P: ToString>(model: Model, prompt_str: P) -> String {
 ///     .await
 /// # }
 /// ```
-pub fn chat(model: Model) -> ChatBuilder {
+pub fn chat(model: impl Into<String>) -> ChatBuilder {
     ChatBuilder::new(model)
 }
 


### PR DESCRIPTION
Upgrades the Rust `ic-llm` library to **2.0.0**, targeting the v1.1.0 llm canister which introduces paid models charged in cycles. Mirrors the Motoko change in #64. Includes the matching update to `quickstart-agent-rust`.

## Library (`rust/`)

- **Cycles for paid models.** `send()` now attaches **100B cycles** to every `v1_chat` call (via `Call::with_cycles`). Paid models are billed from these cycles (any unused portion is refunded); free models refund the full amount. Because cycles are always attached, the calling canister must hold at least 100B cycles when `send()` runs — this applies even for free models.
- **Models are plain strings.** `ic_llm::chat` / `ic_llm::prompt` and `ChatBuilder::new` now take `impl Into<String>` (e.g. `"llama3.1:8b"`, `"gemma3:27b"`) instead of the `Model` enum. Models are added frequently, so this lets consumers use new models without waiting for a library release. The `Model` enum (and its `Display` impl) is removed.
- **Docs.** Refresh the README (model table with free/paid pricing + a section on cycle attachment) and all doctests.

## Example (`examples/quickstart-agent-rust/`)

- `icp.yaml`: the local `llm` canister now uses the v1.1.0 wasm in `https` runtime mode.
- Backend switched to the string-model API.
- README: documents obtaining an Internet Intelligence Gateway API key (sign up at https://inference.internetcomputer.org/beta) and the `https` init args.

## Breaking changes

- `ic_llm::chat(model)` / `ic_llm::prompt(model, ...)` / `ChatBuilder::new(model)` take a string model name instead of the `Model` enum.
- The `Model` enum is removed.

Migration:

```rust
// before
ic_llm::chat(ic_llm::Model::Llama3_1_8B)
// after
ic_llm::chat("llama3.1:8b")
```

## Testing

- `cargo test` (16 unit tests + 11 doctests), `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo fmt -- --check` all pass.
- Verified the example backend compiles against the local `ic-llm` 2.0.0.

Refs: DEFI-2832