### PR TITLE
feat(motoko)!: support cloud engines in the Motoko library

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,15 +25,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install dfx
-        uses: dfinity/setup-dfx@main
-
-      - name: Install mops
-        run: |
-          dfx cache install
-          echo "$(dfx cache show)" >> $GITHUB_PATH
-          curl -fsSL cli.mops.one/install.sh | sh
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Setup mise
+        uses: jdx/mise-action@v3
+        with:
+          cache: false
 
       - name: Run Motoko tests
         working-directory: ./motoko

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 rust = { version = "1.94.0", components = "rustfmt,clippy", targets = "wasm32-unknown-unknown" }
 pnpm = "10.9.0"
 node = "22"
+"npm:ic-mops" = "2.19.2"
 
 [env]
 _.path = ["./node_modules/.bin"]

--- a/motoko/README.md
+++ b/motoko/README.md
@@ -7,12 +7,58 @@ A library for making requests to the LLM canister on the Internet Computer.
 Models are identified by their string name (passed to `LLM.prompt` and
 `LLM.chat`). See the [Intelligence Gateway Homepage](https://inference.internetcomputer.org/) for the authoritative, up-to-date list.
 
+## Examples
+
+The simplest interaction is a single prompt, which returns the reply text
+directly:
+
+```motoko
+import LLM "mo:llm";
+
+let answer = await LLM.prompt("llama3.1:8b", "Write a haiku about the Internet Computer.");
+```
+
+For a multi-turn conversation, build a chat from a list of messages:
+
+```motoko
+import LLM "mo:llm";
+
+let response = await LLM.chat("llama3.1:8b").withMessages([
+  #system_ { content = "You are a helpful assistant for Internet Computer developers." },
+  #user { content = "Suggest a fun name for my new canister." },
+]).send();
+
+let reply = switch (response.message.content) {
+  case (?text) text;
+  case null "";
+};
+```
+
+To pay per request, attach cycles with `.withCycles()` (see
+[Paying for Models](#paying-for-models)):
+
+```motoko
+let response = await LLM.chat("gemma3:27b").withMessages([
+  #system_ { content = "You are a helpful assistant for Internet Computer developers." },
+  #user { content = "Suggest a fun name for my new canister." },
+]).withCycles().send();
+```
+
 ## Paying for Models
 
-For paid models, `send()` attaches 100B cycles to the request — the model
-charges only what it needs and refunds the rest — **so the calling canister must
-hold at least 100B cycles or the call traps**. Free models are called with no
-cycles attached, so the caller doesn't need to hold any.
+Paying for inference can be done in two ways.
+
+1. **Deposit cycles up front.** Add a cycles balance at
+   [inference.internetcomputer.org](https://inference.internetcomputer.org). The
+   LLM canister draws from that balance, so requests need no attached cycles —
+   just call without `.withCycles()`. This works on **both mainnet and cloud
+   engines**.
+
+2. **Attach cycles per request.** Call `.withCycles()` on the builder and
+   `send()` attaches 100B cycles (the model charges only what it needs and
+   refunds the rest), **so the calling canister must hold at least 100B cycles or
+   the call traps**. This works on **mainnet only** — cloud engine canisters
+   cannot send cross-subnet messages that carry attached cycles.
 
 ## Local Development
 
@@ -34,29 +80,4 @@ project — `icp.yaml`, deploying locally, and calling the agent.
 
 ```
 mops add llm
-```
-
-## Usage
-
-### Prompting (single message)
-
-The simplest way to interact with a model is by sending a single prompt:
-
-```motoko
-import LLM "mo:llm";
-
-let answer = await LLM.prompt("llama3.1:8b", "Write a haiku about the Internet Computer.");
-```
-
-### Chatting (multiple messages)
-
-For more complex interactions, send multiple messages in a conversation:
-
-```motoko
-import LLM "mo:llm";
-
-let response = await LLM.chat("llama3.1:8b").withMessages([
-  #system_ { content = "You are a helpful assistant for Internet Computer developers." },
-  #user { content = "Suggest a fun name for my new canister." },
-]).send();
 ```

--- a/motoko/mops.toml
+++ b/motoko/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm"
-version = "3.1.1"
+version = "4.0.0"
 description = "Library for the LLM canister"
 repository = "https://github.com/dfinity/llm/motoko"
 keywords = [ "llm", "ai", "agent" ]

--- a/motoko/mops.toml
+++ b/motoko/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llm"
-version = "3.1.0"
+version = "3.1.1"
 description = "Library for the LLM canister"
 repository = "https://github.com/dfinity/llm/motoko"
 keywords = [ "llm", "ai", "agent" ]

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -29,12 +29,7 @@ module {
     /// accept no cycles, so we attach none — see `FREE_MODELS`.
     let CYCLES_PER_CHAT : Nat = 100_000_000_000;
 
-    /// Deadline (in seconds) for a `v1_chat` call, after which the system may
-    /// return a `SYS_UNKNOWN` reject instead of the actual response. Bounded
-    /// wait keeps the caller upgradeable — an unbounded wait would block
-    /// upgrades indefinitely if the LLM canister became unresponsive — and
-    /// lets the library be called from cloud engine canisters. Mirrors the
-    /// Rust library's 5-minute `change_timeout(300)`.
+    /// Deadline (in seconds) for a `v1_chat` call.
     let CHAT_TIMEOUT_SECONDS : Nat32 = 300;
 
     /// Models that are free to call. Requests to these attach no cycles, so the
@@ -111,20 +106,13 @@ module {
 
         /// Sends the chat request to the LLM canister.
         ///
-        /// Uses bounded wait with a `CHAT_TIMEOUT_SECONDS` deadline so an
-        /// unresponsive LLM canister cannot block the caller's upgrades
-        /// indefinitely. If the deadline expires (or the subnet runs low on
-        /// resources), the system returns a `SYS_UNKNOWN` reject, which traps
-        /// this call — wrap `send()` in `try/catch` to handle that case.
-        ///
         /// Paid models get `CYCLES_PER_CHAT` cycles attached (the calling
         /// canister must hold at least that many or this call traps); free
         /// models get none.
         public func send() : async Response {
             let request = build();
             let cyclesToAttach = if (isFreeModel(_model)) 0 else CYCLES_PER_CHAT;
-            let boundedWait = { timeout = CHAT_TIMEOUT_SECONDS };
-            await (boundedWait with cycles = cyclesToAttach) llmCanister<system>().v1_chat(request)
+            await (with cycles = cyclesToAttach; timeout = CHAT_TIMEOUT_SECONDS) llmCanister<system>().v1_chat(request)
         };
     };
 };

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -1,118 +1,117 @@
 import Prim "mo:⛔";
+import Principal "mo:base/Principal";
 import Tool "./tool";
 
 module {
-    /// The mainnet principal of the LLM canister.
-    let MAINNET_LLM_CANISTER = "w36hm-eqaaa-aaaal-qr76a-cai";
+  /// The mainnet principal of the LLM canister.
+  let MAINNET_LLM_CANISTER = "w36hm-eqaaa-aaaal-qr76a-cai";
 
-    type LlmCanister = actor {
-        v1_chat : (Request) -> async Response;
+  type LlmCanister = actor {
+    v1_chat : (Request) -> async Response;
+  };
+
+  /// Resolves the LLM canister principal to call.
+  ///
+  /// Prefers the `PUBLIC_CANISTER_ID:llm` environment variable (auto-injected
+  /// by `icp deploy` so the library targets the local `llm` canister during
+  /// development) and otherwise falls back to the mainnet canister.
+  func llmCanisterId<system>() : Principal {
+    switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:llm")) {
+      case (?principal) Principal.fromText(principal);
+      case null Principal.fromText(MAINNET_LLM_CANISTER);
+    };
+  };
+
+  /// Resolves the LLM canister to call.
+  func llmCanister<system>() : LlmCanister {
+    actor (Principal.toText(llmCanisterId<system>())) : LlmCanister;
+  };
+
+  /// Cycles attached to a `v1_chat` call when the caller opts in via
+  /// `ChatBuilder.withCycles`.
+  ///
+  /// Paid models require a minimum of 100B cycles to accept a request; they
+  /// charge only what the request costs and refund the remainder. Free models
+  /// accept no cycles. Whether to attach is the caller's decision — this
+  /// library no longer guesses from the model name.
+  let CYCLES_PER_CHAT : Nat = 100_000_000_000;
+
+  /// Deadline (in seconds) for a `v1_chat` call.
+  let CHAT_TIMEOUT_SECONDS : Nat32 = 300;
+
+  /// A message in a chat.
+  public type ChatMessage = {
+    #user : { content : Text };
+    #system_ : { content : Text };
+    #assistant : AssistantMessage;
+    #tool : { content : Text; tool_call_id : Text };
+  };
+
+  public type Response = {
+    message : AssistantMessage;
+  };
+
+  public type AssistantMessage = {
+    content : ?Text;
+    tool_calls : [Tool.ToolCall];
+  };
+
+  /// Request type sent to the LLM canister
+  public type Request = {
+    model : Text;
+    messages : [ChatMessage];
+    tools : ?[Tool.Tool];
+  };
+
+  /// Builder for creating and sending chat requests to the LLM canister.
+  public class ChatBuilder(model : Text) = self {
+    private var _model : Text = model;
+    private var _messages : [ChatMessage] = [];
+    private var _tools : [Tool.Tool] = [];
+    private var _attachCycles : Bool = false;
+
+    /// Sets the messages for the chat.
+    public func withMessages(messages : [ChatMessage]) : ChatBuilder {
+      _messages := messages;
+      self;
     };
 
-    /// Resolves the LLM canister to call.
+    /// Sets the tools for the chat.
+    public func withTools(tools : [Tool.Tool]) : ChatBuilder {
+      _tools := tools;
+      self;
+    };
+
+    /// Attaches cycles to the request (100B cycles).
     ///
-    /// Prefers the `PUBLIC_CANISTER_ID:llm` environment variable (auto-injected
-    /// by `icp deploy` so the library targets the local `llm` canister during
-    /// development) and otherwise falls back to the mainnet canister.
-    func llmCanister<system>() : LlmCanister {
-        let id = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:llm")) {
-            case (?principal) principal;
-            case null MAINNET_LLM_CANISTER;
-        };
-        actor (id) : LlmCanister;
+    /// Call this when you want to pay for models using attached cycles.
+    /// By default, no cycles are attached and your request is charged
+    /// against the canister's balance on IIG.
+    public func withCycles() : ChatBuilder {
+      _attachCycles := true;
+      self;
     };
 
-    /// Cycles attached to a `v1_chat` call for a paid model.
-    ///
-    /// Paid models require a minimum of 100B cycles to accept a request; they
-    /// charge only what the request costs and refund the remainder. Free models
-    /// accept no cycles, so we attach none — see `FREE_MODELS`.
-    let CYCLES_PER_CHAT : Nat = 100_000_000_000;
+    /// Builds the chat request without sending it.
+    public func build() : Request {
+      let tools_option = if (_tools.size() == 0) {
+        null;
+      } else {
+        ?_tools;
+      };
 
-    /// Deadline (in seconds) for a `v1_chat` call.
-    let CHAT_TIMEOUT_SECONDS : Nat32 = 300;
-
-    /// Models that are free to call. Requests to these attach no cycles, so the
-    /// calling canister doesn't need to hold any. Every other model is treated
-    /// as paid and gets `CYCLES_PER_CHAT` attached.
-    let FREE_MODELS = ["llama3.1:8b", "qwen3:32b"];
-
-    func isFreeModel(model : Text) : Bool {
-        for (freeModel in FREE_MODELS.vals()) {
-            if (freeModel == model) return true;
-        };
-        false;
+      {
+        model = _model;
+        messages = _messages;
+        tools = tools_option;
+      };
     };
 
-    /// A message in a chat.
-    public type ChatMessage = {
-        #user : { content : Text };
-        #system_ : { content : Text };
-        #assistant : AssistantMessage;
-        #tool : { content : Text; tool_call_id : Text };
+    /// Sends the chat request to the LLM canister.
+    public func send() : async Response {
+      let request = build();
+      let cyclesToAttach = if (_attachCycles) CYCLES_PER_CHAT else 0;
+      await (with cycles = cyclesToAttach; timeout = CHAT_TIMEOUT_SECONDS) llmCanister<system>().v1_chat(request);
     };
-
-    public type Response = {
-        message : AssistantMessage;
-    };
-
-    public type AssistantMessage = {
-        content : ?Text;
-        tool_calls : [Tool.ToolCall];
-    }; 
- 
-    /// Request type sent to the LLM canister
-    public type Request = {
-        model : Text;
-        messages : [ChatMessage];
-        tools : ?[Tool.Tool];
-    };
-
-    /// Builder for creating and sending chat requests to the LLM canister.
-    ///
-    /// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free)
-    /// or `"gemma3:27b"` (paid). See the README for the current list.
-    public class ChatBuilder(model : Text) = self {
-        private var _model : Text = model;
-        private var _messages : [ChatMessage] = [];
-        private var _tools : [Tool.Tool] = [];
-
-        /// Sets the messages for the chat.
-        public func withMessages(messages : [ChatMessage]) : ChatBuilder {
-            _messages := messages;
-            self;
-        };
-
-        /// Sets the tools for the chat.
-        public func withTools(tools : [Tool.Tool]) : ChatBuilder {
-            _tools := tools;
-            self;
-        };
-
-        /// Builds the chat request without sending it.
-        public func build() : Request {
-            let tools_option = if (_tools.size() == 0) {
-                null;
-            } else {
-                ?_tools;
-            };
-
-            {
-                model = _model;
-                messages = _messages;
-                tools = tools_option;
-            }
-        };
-
-        /// Sends the chat request to the LLM canister.
-        ///
-        /// Paid models get `CYCLES_PER_CHAT` cycles attached (the calling
-        /// canister must hold at least that many or this call traps); free
-        /// models get none.
-        public func send() : async Response {
-            let request = build();
-            let cyclesToAttach = if (isFreeModel(_model)) 0 else CYCLES_PER_CHAT;
-            await (with cycles = cyclesToAttach; timeout = CHAT_TIMEOUT_SECONDS) llmCanister<system>().v1_chat(request)
-        };
-    };
+  };
 };

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -1,5 +1,4 @@
 import Prim "mo:⛔";
-import Principal "mo:base/Principal";
 import Tool "./tool";
 
 module {
@@ -10,21 +9,17 @@ module {
     v1_chat : (Request) -> async Response;
   };
 
-  /// Resolves the LLM canister principal to call.
+  /// Resolves the LLM canister to call.
   ///
   /// Prefers the `PUBLIC_CANISTER_ID:llm` environment variable (auto-injected
   /// by `icp deploy` so the library targets the local `llm` canister during
   /// development) and otherwise falls back to the mainnet canister.
-  func llmCanisterId<system>() : Principal {
-    switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:llm")) {
-      case (?principal) Principal.fromText(principal);
-      case null Principal.fromText(MAINNET_LLM_CANISTER);
-    };
-  };
-
-  /// Resolves the LLM canister to call.
   func llmCanister<system>() : LlmCanister {
-    actor (Principal.toText(llmCanisterId<system>())) : LlmCanister;
+    let id = switch (Prim.envVar<system>("PUBLIC_CANISTER_ID:llm")) {
+      case (?principal) principal;
+      case null MAINNET_LLM_CANISTER;
+    };
+    actor (id) : LlmCanister;
   };
 
   /// Cycles attached to a `v1_chat` call when the caller opts in via

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -29,6 +29,14 @@ module {
     /// accept no cycles, so we attach none — see `FREE_MODELS`.
     let CYCLES_PER_CHAT : Nat = 100_000_000_000;
 
+    /// Deadline (in seconds) for a `v1_chat` call, after which the system may
+    /// return a `SYS_UNKNOWN` reject instead of the actual response. Bounded
+    /// wait keeps the caller upgradeable — an unbounded wait would block
+    /// upgrades indefinitely if the LLM canister became unresponsive — and
+    /// lets the library be called from cloud engine canisters. Mirrors the
+    /// Rust library's 5-minute `change_timeout(300)`.
+    let CHAT_TIMEOUT_SECONDS : Nat32 = 300;
+
     /// Models that are free to call. Requests to these attach no cycles, so the
     /// calling canister doesn't need to hold any. Every other model is treated
     /// as paid and gets `CYCLES_PER_CHAT` attached.
@@ -103,13 +111,20 @@ module {
 
         /// Sends the chat request to the LLM canister.
         ///
+        /// Uses bounded wait with a `CHAT_TIMEOUT_SECONDS` deadline so an
+        /// unresponsive LLM canister cannot block the caller's upgrades
+        /// indefinitely. If the deadline expires (or the subnet runs low on
+        /// resources), the system returns a `SYS_UNKNOWN` reject, which traps
+        /// this call — wrap `send()` in `try/catch` to handle that case.
+        ///
         /// Paid models get `CYCLES_PER_CHAT` cycles attached (the calling
         /// canister must hold at least that many or this call traps); free
         /// models get none.
         public func send() : async Response {
             let request = build();
             let cyclesToAttach = if (isFreeModel(_model)) 0 else CYCLES_PER_CHAT;
-            await (with cycles = cyclesToAttach) llmCanister<system>().v1_chat(request)
+            let boundedWait = { timeout = CHAT_TIMEOUT_SECONDS };
+            await (boundedWait with cycles = cyclesToAttach) llmCanister<system>().v1_chat(request)
         };
     };
 };

--- a/motoko/src/lib.mo
+++ b/motoko/src/lib.mo
@@ -9,7 +9,6 @@ module {
   public type Response = Chat.Response;
   public type Request = Chat.Request;
 
-
   public func prompt(model : Text, promptStr : Text) : async Text {
     let response = await Chat.ChatBuilder(model).withMessages([
       #user({
@@ -27,11 +26,11 @@ module {
     Chat.ChatBuilder(model);
   };
 
-  public func tool(name: Text) : Tool.ToolBuilder {
-    Tool.ToolBuilder(name)
+  public func tool(name : Text) : Tool.ToolBuilder {
+    Tool.ToolBuilder(name);
   };
 
-  public func parameter(name: Text, type_: Tool.ParameterType) : Tool.ParameterBuilder {
-    Tool.ParameterBuilder(name, type_)
+  public func parameter(name : Text, type_ : Tool.ParameterType) : Tool.ParameterBuilder {
+    Tool.ParameterBuilder(name, type_);
   };
 };

--- a/motoko/test/chat.test.mo
+++ b/motoko/test/chat.test.mo
@@ -3,97 +3,126 @@ import Tool "../src/tool";
 import { test } "mo:test";
 
 test(
-    "create chat builder",
-    func() {
-        let builder = Chat.ChatBuilder("llama3.1:8b");
+  "create chat builder",
+  func() {
+    let builder = Chat.ChatBuilder("llama3.1:8b");
 
-        let request = builder.build();
-        assert request == {
-            model = "llama3.1:8b";
-            messages = [];
-            tools = null;
-        };
-    },
+    let request = builder.build();
+    assert request == {
+      model = "llama3.1:8b";
+      messages = [];
+      tools = null;
+    };
+  },
 );
 
 test(
-    "chat builder with messages",
-    func() {
-        let messages : [Chat.ChatMessage] = [
-            #system_ { content = "You are a helpful assistant" },
-            #user { content = "Hello" },
-        ];
+  "chat builder with messages",
+  func() {
+    let messages : [Chat.ChatMessage] = [
+      #system_ { content = "You are a helpful assistant" },
+      #user { content = "Hello" },
+    ];
 
-        let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages);
-        
-        let request = builder.build();
-        assert request == {
-            model = "llama3.1:8b";
-            messages = messages;
-            tools = null;
-        };
-    },
+    let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages);
+
+    let request = builder.build();
+    assert request == {
+      model = "llama3.1:8b";
+      messages = messages;
+      tools = null;
+    };
+  },
 );
 
 test(
-    "chat builder with tools",
-    func() {
-        let tool = (Tool.ToolBuilder("test_tool"))
-            .withDescription("A test tool")
-            .build();
+  "chat builder with tools",
+  func() {
+    let tool = (Tool.ToolBuilder("test_tool")).withDescription("A test tool").build();
 
-        let builder = Chat.ChatBuilder("llama3.1:8b").withTools([tool]);
-        
-        let request = builder.build();
-        assert request == {
-            model = "llama3.1:8b";
-            messages = [];
-            tools = ?[tool];
-        };
-    },
+    let builder = Chat.ChatBuilder("llama3.1:8b").withTools([tool]);
+
+    let request = builder.build();
+    assert request == {
+      model = "llama3.1:8b";
+      messages = [];
+      tools = ?[tool];
+    };
+  },
 );
 
 test(
-    "chat builder with messages and tools",
-    func() {
-        let messages : [Chat.ChatMessage] = [
-            #user { content = "Hello" },
-        ];
+  "chat builder with messages and tools",
+  func() {
+    let messages : [Chat.ChatMessage] = [
+      #user { content = "Hello" },
+    ];
 
-        let tool = (Tool.ToolBuilder("test_tool")).build();
+    let tool = (Tool.ToolBuilder("test_tool")).build();
 
-        let builder = Chat.ChatBuilder("llama3.1:8b")
-            .withMessages(messages)
-            .withTools([tool]);
-            
-        let request = builder.build();
-        assert request == {
-            model = "llama3.1:8b";
-            messages = messages;
-            tools = ?[tool];
-        };
-    },
+    let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages).withTools([tool]);
+
+    let request = builder.build();
+    assert request == {
+      model = "llama3.1:8b";
+      messages = messages;
+      tools = ?[tool];
+    };
+  },
 );
 
 test(
-    "function call get",
-    func() {
-        let function_call : Tool.FunctionCall = {
-            name = "test_function";
-            arguments = [
-                {
-                    name = "arg1";
-                    value = "value1";
-                },
-                {
-                    name = "arg2";
-                    value = "value2";
-                },
-            ];
-        };
+  "function call get",
+  func() {
+    let function_call : Tool.FunctionCall = {
+      name = "test_function";
+      arguments = [
+        {
+          name = "arg1";
+          value = "value1";
+        },
+        {
+          name = "arg2";
+          value = "value2";
+        },
+      ];
+    };
 
-        assert Tool.getArgument(function_call, "arg1") == ?"value1";
-        assert Tool.getArgument(function_call, "arg2") == ?"value2";
-        assert Tool.getArgument(function_call, "arg3") == null;
-    },
+    assert Tool.getArgument(function_call, "arg1") == ?"value1";
+    assert Tool.getArgument(function_call, "arg2") == ?"value2";
+    assert Tool.getArgument(function_call, "arg3") == null;
+  },
+);
+
+test(
+  "withCycles is chainable and does not affect build()",
+  func() {
+    let builder = Chat.ChatBuilder("gemma3:27b").withCycles();
+
+    let request = builder.build();
+    assert request == {
+      model = "gemma3:27b";
+      messages = [];
+      tools = null;
+    };
+  },
+);
+
+test(
+  "withCycles composes with withMessages and withTools",
+  func() {
+    let messages : [Chat.ChatMessage] = [
+      #user { content = "Hello" },
+    ];
+    let tool = (Tool.ToolBuilder("test_tool")).build();
+
+    let builder = Chat.ChatBuilder("gemma3:27b").withMessages(messages).withTools([tool]).withCycles();
+
+    let request = builder.build();
+    assert request == {
+      model = "gemma3:27b";
+      messages = messages;
+      tools = ?[tool];
+    };
+  },
 );


### PR DESCRIPTION
## Problem

The `llm` package in Motoko didn't support cloud engines, for the following reasons:

- Calls to the LLM canister were unbounded - not supported on cloud engines.
- Calls attached cycles by default - cycle attachments aren't supported on cloud engines.

## Solution

- Calls now use a bounded wait with a 5-minute deadline.
- Attaching cycles is now an explicit decision via `withCycles`; by default none are attached. Note `withCycles` works on mainnet only.
- To pay from a cloud engine (or mainnet), top up a balance on IIG and the canister draws from it - no attached cycles needed.

NOTE: breaking change — bumped to 4.0.0.