### PR TITLE
feat(rust)!: support cloud engines in the Rust library

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "ic-llm"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "candid",
  "ic-cdk",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-llm"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.94"
 description = "A library for making requests to the LLM canister on the Internet Computer"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,302 +1,101 @@
 # `ic-llm`
 
-
 A library for making requests to the LLM canister on the Internet Computer.
 
 ## Supported Models
 
 Models are identified by their string name (passed to `ic_llm::prompt` and
-`ic_llm::chat`). The available models are:
+`ic_llm::chat`). See the [Intelligence Gateway Homepage](https://inference.internetcomputer.org/) for the authoritative, up-to-date list.
 
-| Model string      | Pricing |
-| ----------------- | ------- |
-| `"llama3.1:8b"`   | Free    |
-| `"qwen3:32b"`     | Free    |
-| `"llama4-scout"`  | Free    |
-| `"qwen2.5:0.5b"`  | Free    |
-| `"gemma3:27b"`    | Paid    |
-| `"z-ai:glm-5.2"`  | Paid    |
+## Examples
 
-Models are added frequently — see the [LLM canister](../README.md) for the
-authoritative, up-to-date list.
-
-### Paying for models
-
-`send()` automatically attaches 100B cycles to every request. Paid models are
-charged from those cycles (any unused portion is refunded); free models refund
-the full amount. Because cycles are always attached, **the calling canister must
-hold at least 100B cycles when `send()` runs, or the call traps** — this applies
-even when using a free model.
-
-## Local Development
-
-When developing locally, the architecture differs slightly from mainnet: instead
-of relying on AI workers, the LLM canister connects directly to a local
-[Ollama](https://ollama.com/) instance. The interface is identical to mainnet —
-see [How Does it Work?](../README.md#how-does-it-work) for details.
-
-Before running an agent locally, start Ollama and pull the model you intend to
-use:
-
-```bash
-ollama serve
-ollama run llama3.1:8b   # one-time download
-```
-
-For complete, working project setups — including how to deploy the LLM canister
-locally — see the examples in this repository (e.g.
-[`examples/quickstart-agent-rust`](../examples/quickstart-agent-rust)).
-
-## Usage
-
-### Basic Usage
-
-#### Prompting (Single Message)
-
-The simplest way to interact with a model is by sending a single prompt:
+The simplest interaction is a single prompt, which returns the reply text
+directly:
 
 ```rust
 async fn example() -> String {
-    ic_llm::prompt("llama3.1:8b", "What's the speed of light?").await
+    ic_llm::prompt("llama3.1:8b", "Write a haiku about the Internet Computer.").await
 }
 ```
 
-#### Chatting (Multiple Messages)
+For a multi-turn conversation, build a chat from a list of messages:
 
-For more complex interactions, you can send multiple messages in a conversation:
+```rust
+use ic_llm::ChatMessage;
+
+async fn example() -> String {
+    let response = ic_llm::chat("llama3.1:8b")
+        .with_messages(vec![
+            ChatMessage::System {
+                content: "You are a helpful assistant for Internet Computer developers.".to_string(),
+            },
+            ChatMessage::User {
+                content: "Suggest a fun name for my new canister.".to_string(),
+            },
+        ])
+        .send()
+        .await;
+
+    response.message.content.unwrap_or_default()
+}
+```
+
+To pay per request, attach cycles with `.with_cycles()` (see
+[Paying for Models](#paying-for-models)):
 
 ```rust
 use ic_llm::ChatMessage;
 
 async fn example() {
-    ic_llm::chat("llama3.1:8b")
+    ic_llm::chat("gemma3:27b")
         .with_messages(vec![
             ChatMessage::System {
-                content: "You are a helpful assistant".to_string(),
+                content: "You are a helpful assistant for Internet Computer developers.".to_string(),
             },
             ChatMessage::User {
-                content: "How big is the sun?".to_string(),
+                content: "Suggest a fun name for my new canister.".to_string(),
             },
         ])
+        .with_cycles()
         .send()
         .await;
 }
 ```
 
-### Choosing the LLM canister
+## Paying for Models
 
-By default the SDK addresses the mainnet LLM canister (`w36hm-eqaaa-aaaal-qr76a-cai`).
-When your canister is deployed with `icp deploy`, the SDK transparently picks up
-`PUBLIC_CANISTER_ID:llm` if it has been auto-injected — so the same code works
-against a local `llm` canister whose principal differs from mainnet, with no
-caller-side changes.
+Paying for inference can be done in two ways.
 
-For other cases (a fork, a mock, a staging deployment under a different name),
-override the canister explicitly:
+1. **Deposit cycles up front.** Add a cycles balance at
+   [inference.internetcomputer.org](https://inference.internetcomputer.org). The
+   LLM canister draws from that balance, so requests need no attached cycles —
+   just call without `.with_cycles()`. This works on **both mainnet and cloud
+   engines**.
 
-```rust
-use candid::Principal;
-async fn example() {
-    let custom = Principal::from_text("aaaaa-aa").unwrap();
-    ic_llm::chat("llama3.1:8b")
-        .with_canister(custom)
-        .with_messages(vec![])
-        .send()
-        .await;
-}
-```
+2. **Attach cycles per request.** Call `.with_cycles()` on the builder and
+   `send()` attaches 100B cycles (the model charges only what it needs and
+   refunds the rest), **so the calling canister must hold at least 100B cycles or
+   the call traps**. This works on **mainnet only** — cloud engine canisters
+   cannot send cross-subnet messages that carry attached cycles.
 
-### Advanced Usage with Tools
+## Local Development
 
-#### Understanding Tools
+The library resolves which `llm` canister to call at runtime, so the same code
+works locally and on mainnet:
 
-**Tools** are custom functions that you define and make available to the LLM. 
-They allow the AI to perform actions beyond just generating text responses.
-When you provide tools to the LLM, it can decide when and how to use them based on the user's request.
+- **Mainnet:** it calls the canonical LLM canister
+  (`w36hm-eqaaa-aaaal-qr76a-cai`), which requires no API key.
+- **Locally:** `icp deploy` injects the local `llm` canister's principal as the
+  `PUBLIC_CANISTER_ID:llm` environment variable and the library picks it up
+  automatically. The local `llm` canister runs in `https` mode and needs an
+  [Internet Intelligence Gateway](https://inference.internetcomputer.org/) API
+  key to serve prompts.
 
-**Common use cases for tools:**
-- **Data retrieval**: Fetching real-time information (prices, weather, account balances)
-- **External API calls**: Integrating with third-party services
-- **Calculations**: Performing complex computations
-- **Database operations**: Querying or updating data
-- **Custom business logic**: Executing domain-specific functions
+See the [quickstart example](../examples/quickstart-agent-rust) for a complete
+project — `icp.yaml`, deploying locally, and calling the agent.
 
-**How it works:**
-1. You define available tools with their parameters
-2. The LLM analyzes the user's request
-3. If a tool would be helpful, the LLM returns a "tool call" instead of a direct answer
-4. Your code executes the requested tool with the LLM's provided parameters
-5. You send the tool's result back to the LLM
-6. The LLM incorporates the result into its final response
+## Install
 
-#### Defining and Using a Tool
-
-You can define tools that the LLM can use to perform actions:
-
-```rust
-use ic_llm::{ChatMessage, ParameterType};
-
-async fn example() {
-    ic_llm::chat("llama3.1:8b")
-        .with_messages(vec![
-            ChatMessage::System {
-                content: "You are a helpful assistant".to_string(),
-            },
-            ChatMessage::User {
-                content: "What's the balance of account abc123?".to_string(),
-            },
-        ])
-        .with_tools(vec![
-            ic_llm::tool("icp_account_balance")
-                .with_description("Lookup the balance of an ICP account")
-                .with_parameter(
-                    ic_llm::parameter("account", ParameterType::String)
-                        .with_description("The ICP account to look up")
-                        .is_required()
-                )
-                .build()
-        ])
-        .send()
-        .await;
-}
-```
-
-#### Handling Tool Calls from the LLM
-
-When the LLM decides to use one of your tools, you can handle the call:
-
-```rust
-use ic_llm::{ChatMessage, ParameterType, Response};
-
-async fn example() -> Response {
-    let response = ic_llm::chat("llama3.1:8b")
-        .with_messages(vec![
-            ChatMessage::System {
-                content: "You are a helpful assistant".to_string(),
-            },
-            ChatMessage::User {
-                content: "What's the weather in San Francisco?".to_string(),
-            },
-        ])
-        .with_tools(vec![
-            ic_llm::tool("get_weather")
-                .with_description("Get current weather for a location")
-                .with_parameter(
-                    ic_llm::parameter("location", ParameterType::String)
-                        .with_description("The location to get weather for")
-                        .is_required()
-                )
-                .build()
-        ])
-        .send()
-        .await;
-    
-    // Process tool calls if any
-    for tool_call in &response.message.tool_calls {
-        match tool_call.function.name.as_str() {
-            "get_weather" => {
-                // Extract the location parameter
-                let location = tool_call.function.get("location").unwrap();
-                // Call your weather API or service
-                let weather = get_weather(&location).await;
-                // You would typically send this information back to the LLM in a follow-up message
-            }
-            _ => {} // Handle other tool calls
-        }
-    }
-    
-    response
-}
-
-// Mock function for getting weather
-async fn get_weather(location: &str) -> String {
-    format!("Weather in {}: Sunny, 72°F", location)
-}
-```
-
-#### Complete Tool Usage Example
-
-Here's a more complete example showing how to handle tool calls and continue the conversation:
-
-```rust
-use ic_llm::{ChatMessage, ParameterType, Response};
-
-async fn handle_chat_with_tools(user_message: String) -> String {
-    let mut messages = vec![
-        ChatMessage::System {
-            content: "You are a helpful assistant".to_string(),
-        },
-        ChatMessage::User {
-            content: user_message,
-        },
-    ];
-
-    let tools = vec![
-        ic_llm::tool("get_weather")
-            .with_description("Get current weather for a location")
-            .with_parameter(
-                ic_llm::parameter("location", ParameterType::String)
-                    .with_description("The location to get weather for")
-                    .is_required()
-            )
-            .build(),
-        ic_llm::tool("get_icp_price")
-            .with_description("Get the current ICP token price")
-            .build()
-    ];
-
-    let response = ic_llm::chat("llama3.1:8b")
-        .with_messages(messages.clone())
-        .with_tools(tools)
-        .send()
-        .await;
-
-    // Check if LLM wants to use tools
-    if !response.message.tool_calls.is_empty() {
-        // Add assistant message with tool calls
-        messages.push(ChatMessage::Assistant(response.message.clone()));
-
-        // Process each tool call
-        for tool_call in &response.message.tool_calls {
-            let tool_result = match tool_call.function.name.as_str() {
-                "get_weather" => {
-                    let location = tool_call.function.get("location").unwrap_or_default();
-                    get_weather(&location).await
-                }
-                "get_icp_price" => {
-                    get_icp_price().await
-                }
-                _ => format!("Unknown tool: {}", tool_call.function.name)
-            };
-
-            // Add tool result to conversation
-            messages.push(ChatMessage::Tool {
-                content: tool_result,
-                tool_call_id: tool_call.id.clone(),
-            });
-        }
-
-        // Get final response from LLM with tool results
-        let final_response = ic_llm::chat("llama3.1:8b")
-            .with_messages(messages)
-            .send()
-            .await;
-
-        final_response.message.content.unwrap_or_default()
-    } else {
-        // No tool calls needed, return direct response
-        response.message.content.unwrap_or_default()
-    }
-}
-
-// Example tool implementations
-async fn get_weather(location: &str) -> String {
-    // In a real implementation, you would call a weather API
-    format!("Weather in {}: Sunny, 72°F", location)
-}
-
-async fn get_icp_price() -> String {
-    // In a real implementation, you would call a price API
-    "Current ICP price: $10.50".to_string()
-}
+```bash
+cargo add ic-llm
 ```

--- a/rust/src/chat.rs
+++ b/rust/src/chat.rs
@@ -2,6 +2,28 @@ use crate::tool::Tool;
 use candid::{CandidType, Principal};
 use serde::{Deserialize, Serialize};
 
+// The mainnet principal of the LLM canister.
+const MAINNET_LLM_CANISTER: &str = "w36hm-eqaaa-aaaal-qr76a-cai";
+
+// Resolves the LLM canister to call.
+//
+// Prefers the `PUBLIC_CANISTER_ID:llm` environment variable (auto-injected by
+// `icp deploy` so the library targets the local `llm` canister during
+// development) and otherwise falls back to the mainnet canister.
+fn default_llm_canister() -> Principal {
+    // The env-var lookup only works in a canister; skip in unit tests.
+    #[cfg(not(test))]
+    {
+        const LLM_CANISTER_ENV: &str = "PUBLIC_CANISTER_ID:llm";
+        if ic_cdk::api::env_var_name_exists(LLM_CANISTER_ENV) {
+            let id = ic_cdk::api::env_var_value(LLM_CANISTER_ENV);
+            return Principal::from_text(&id)
+                .unwrap_or_else(|e| ic_cdk::trap(format!("invalid {LLM_CANISTER_ENV}: {e}")));
+        }
+    }
+    Principal::from_text(MAINNET_LLM_CANISTER).unwrap()
+}
+
 /// A message in a chat.
 #[derive(CandidType, Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum ChatMessage {
@@ -65,16 +87,16 @@ struct Request {
     tools: Option<Vec<Tool>>,
 }
 
-/// Cycles attached to every `v1_chat` call.
+/// Cycles attached to a `v1_chat` call when the caller opts in via
+/// [`ChatBuilder::with_cycles`].
 ///
-/// Paid models require a minimum of 100B cycles to accept a request. Free
-/// models charge nothing: they accept no cycles and the full amount is
-/// refunded. Paid models accept only what's needed to cover the request and
-/// refund the remainder, so attaching this amount unconditionally is safe.
-///
-/// Note: the calling canister must hold at least this many cycles when `send()`
-/// runs, otherwise the call traps.
+/// Paid models require a minimum of 100B cycles to accept a request; they
+/// charge only what the request costs and refund the remainder. Free models
+/// accept no cycles.
 const CYCLES_PER_CHAT: u128 = 100_000_000_000;
+
+/// Deadline (in seconds) for a `v1_chat` call.
+const CHAT_TIMEOUT_SECONDS: u32 = 300;
 
 /// Builder for creating and sending chat requests to the LLM canister.
 #[derive(Debug)]
@@ -82,7 +104,7 @@ pub struct ChatBuilder {
     model: String,
     messages: Vec<ChatMessage>,
     tools: Vec<Tool>,
-    canister: Principal,
+    attach_cycles: bool,
 }
 
 impl ChatBuilder {
@@ -95,7 +117,7 @@ impl ChatBuilder {
             model: model.into(),
             messages: Vec::new(),
             tools: Vec::new(),
-            canister: crate::default_llm_canister(),
+            attach_cycles: false,
         }
     }
 
@@ -111,24 +133,24 @@ impl ChatBuilder {
         self
     }
 
-    /// Overrides the LLM canister to call.
+    /// Attaches cycles to the request (100B cycles).
     ///
-    /// By default the SDK addresses the mainnet LLM canister
-    /// (`w36hm-eqaaa-aaaal-qr76a-cai`), unless `icp deploy` has auto-injected
-    /// `PUBLIC_CANISTER_ID:llm` on this canister — in which case that value is
-    /// used. Set this only when neither default is what you want (e.g. when
-    /// pointing at a fork, a mock, or a staging deployment under a different
-    /// name).
-    pub fn with_canister(mut self, canister: Principal) -> Self {
-        self.canister = canister;
+    /// Call this when you want to pay for models using attached cycles. By
+    /// default, no cycles are attached and your request is charged against the
+    /// canister's balance on IIG.
+    ///
+    /// Paid models charge only what the request costs and refund the remainder;
+    /// free models accept no cycles. Note that the calling canister must hold at
+    /// least 100B cycles when `send()` runs, otherwise the call traps.
+    pub fn with_cycles(mut self) -> Self {
+        self.attach_cycles = true;
         self
     }
 
     /// Sends the chat request to the LLM canister.
     ///
-    /// Attaches `CYCLES_PER_CHAT` cycles to pay for paid models. Free models
-    /// refund the full amount. The calling canister must hold at least that
-    /// many cycles or this call traps.
+    /// Attaches cycles only when [`with_cycles`](Self::with_cycles) was called;
+    /// otherwise the request is charged against the canister's balance on IIG.
     pub async fn send(self) -> Response {
         let tools_option = if self.tools.is_empty() {
             None
@@ -136,9 +158,15 @@ impl ChatBuilder {
             Some(self.tools)
         };
 
-        ic_cdk::call::Call::bounded_wait(self.canister, "v1_chat")
-            .change_timeout(300)
-            .with_cycles(CYCLES_PER_CHAT)
+        let cycles_to_attach = if self.attach_cycles {
+            CYCLES_PER_CHAT
+        } else {
+            0
+        };
+
+        ic_cdk::call::Call::bounded_wait(default_llm_canister(), "v1_chat")
+            .change_timeout(CHAT_TIMEOUT_SECONDS)
+            .with_cycles(cycles_to_attach)
             .with_arg(Request {
                 model: self.model,
                 messages: self.messages,
@@ -194,19 +222,15 @@ mod tests {
     }
 
     #[test]
-    fn chat_builder_defaults_to_mainnet_llm_canister() {
+    fn chat_builder_defaults_to_no_cycles() {
         let builder = ChatBuilder::new("llama3.1:8b");
-        assert_eq!(
-            builder.canister,
-            Principal::from_text(crate::MAINNET_LLM_CANISTER).unwrap(),
-        );
+        assert!(!builder.attach_cycles);
     }
 
     #[test]
-    fn chat_builder_with_canister() {
-        let canister = Principal::from_slice(&[1, 2, 3, 4]);
-        let builder = ChatBuilder::new("llama3.1:8b").with_canister(canister);
-        assert_eq!(builder.canister, canister);
+    fn chat_builder_with_cycles() {
+        let builder = ChatBuilder::new("llama3.1:8b").with_cycles();
+        assert!(builder.attach_cycles);
     }
 
     #[test]

--- a/rust/src/chat.rs
+++ b/rust/src/chat.rs
@@ -111,7 +111,8 @@ impl ChatBuilder {
     /// Creates a new chat builder with a model.
     ///
     /// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free)
-    /// or `"gemma3:27b"` (paid). See the README for the current list.
+    /// or `"gemma3:27b"` (paid). See the [Intelligence Gateway](https://inference.internetcomputer.org/)
+    /// for the current list.
     pub fn new(model: impl Into<String>) -> Self {
         Self {
             model: model.into(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-use candid::Principal;
 
 // Define our modules
 mod chat;
@@ -10,26 +9,6 @@ pub use chat::{AssistantMessage, ChatBuilder, ChatMessage, FunctionCall, Respons
 pub use tool::{
     Function, ParameterBuilder, ParameterType, Parameters, Property, Tool, ToolBuilder,
 };
-
-// The mainnet principal of the LLM canister.
-const MAINNET_LLM_CANISTER: &str = "w36hm-eqaaa-aaaal-qr76a-cai";
-
-/// Resolves the LLM canister principal: prefers `PUBLIC_CANISTER_ID:llm` (auto-injected
-/// by `icp deploy`) and otherwise falls back to the mainnet canister.
-pub(crate) fn default_llm_canister() -> Principal {
-    // The env-var lookup only works in a canister.
-    // Skip in unit tests.
-    #[cfg(not(test))]
-    {
-        const LLM_CANISTER_ENV: &str = "PUBLIC_CANISTER_ID:llm";
-        if ic_cdk::api::env_var_name_exists(LLM_CANISTER_ENV) {
-            let id = ic_cdk::api::env_var_value(LLM_CANISTER_ENV);
-            return Principal::from_text(&id)
-                .unwrap_or_else(|e| ic_cdk::trap(format!("invalid {LLM_CANISTER_ENV}: {e}")));
-        }
-    }
-    Principal::from_text(MAINNET_LLM_CANISTER).unwrap()
-}
 
 /// Sends a single message to a model.
 ///

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,7 +13,8 @@ pub use tool::{
 /// Sends a single message to a model.
 ///
 /// `model` is the canister's model identifier, e.g. `"llama3.1:8b"` (free) or
-/// `"gemma3:27b"` (paid). See the README for the current list.
+/// `"gemma3:27b"` (paid). See the [Intelligence Gateway](https://inference.internetcomputer.org/)
+/// for the current list.
 ///
 /// # Example
 ///


### PR DESCRIPTION
## Problem

The `ic-llm` crate didn't support cloud engines: calls attached cycles by default, and cycle attachments aren't supported on cloud engines.

## Solution

- Attaching cycles is now an explicit decision via `with_cycles`; by default none are attached. Note `with_cycles` works on mainnet only.
- To pay from a cloud engine (or mainnet), top up a balance on IIG and the canister draws from it — no attached cycles needed.
- Remove the `with_canister` API and resolve the LLM canister purely from the `PUBLIC_CANISTER_ID:llm` env var (falling back to mainnet), mirroring the Motoko library.