### PR TITLE
feat(motoko)!: migrate to core, moc 1.14.1, contextual-dot builders

### DIFF
--- a/motoko/mops.toml
+++ b/motoko/mops.toml
@@ -7,10 +7,10 @@ keywords = [ "llm", "ai", "agent" ]
 license = "MIT"
 
 [dependencies]
-base = "0.14.9"
+core = "2.6.1"
 
 [dev-dependencies]
 test = "2.1.1"
 
 [toolchain]
-moc = "1.8.2"
+moc = "1.14.1"

--- a/motoko/src/chat.mo
+++ b/motoko/src/chat.mo
@@ -59,21 +59,32 @@ module {
   };
 
   /// Builder for creating and sending chat requests to the LLM canister.
-  public class ChatBuilder(model : Text) = self {
-    private var _model : Text = model;
-    private var _messages : [ChatMessage] = [];
-    private var _tools : [Tool.Tool] = [];
-    private var _attachCycles : Bool = false;
+  public module ChatBuilder {
+    public type ChatBuilder = {
+      model : Text;
+      var messages : [ChatMessage];
+      var tools : [Tool.Tool];
+      var attachCycles : Bool;
+    };
+
+    public func new(model : Text) : ChatBuilder {
+      {
+        model = model;
+        var messages = [];
+        var tools = [];
+        var attachCycles = false;
+      };
+    };
 
     /// Sets the messages for the chat.
-    public func withMessages(messages : [ChatMessage]) : ChatBuilder {
-      _messages := messages;
+    public func withMessages(self : ChatBuilder, messages : [ChatMessage]) : ChatBuilder {
+      self.messages := messages;
       self;
     };
 
     /// Sets the tools for the chat.
-    public func withTools(tools : [Tool.Tool]) : ChatBuilder {
-      _tools := tools;
+    public func withTools(self : ChatBuilder, tools : [Tool.Tool]) : ChatBuilder {
+      self.tools := tools;
       self;
     };
 
@@ -82,30 +93,24 @@ module {
     /// Call this when you want to pay for models using attached cycles.
     /// By default, no cycles are attached and your request is charged
     /// against the canister's balance on IIG.
-    public func withCycles() : ChatBuilder {
-      _attachCycles := true;
+    public func withCycles(self : ChatBuilder) : ChatBuilder {
+      self.attachCycles := true;
       self;
     };
 
     /// Builds the chat request without sending it.
-    public func build() : Request {
-      let tools_option = if (_tools.size() == 0) {
-        null;
-      } else {
-        ?_tools;
-      };
-
+    public func build(self : ChatBuilder) : Request {
       {
-        model = _model;
-        messages = _messages;
-        tools = tools_option;
+        model = self.model;
+        messages = self.messages;
+        tools = if (self.tools.size() == 0) null else ?self.tools;
       };
     };
 
     /// Sends the chat request to the LLM canister.
-    public func send() : async Response {
-      let request = build();
-      let cyclesToAttach = if (_attachCycles) CYCLES_PER_CHAT else 0;
+    public func send(self : ChatBuilder) : async Response {
+      let request = build(self);
+      let cyclesToAttach = if (self.attachCycles) CYCLES_PER_CHAT else 0;
       await (with cycles = cyclesToAttach; timeout = CHAT_TIMEOUT_SECONDS) llmCanister<system>().v1_chat(request);
     };
   };

--- a/motoko/src/lib.mo
+++ b/motoko/src/lib.mo
@@ -1,5 +1,6 @@
 import Chat "./chat";
 import Tool "./tool";
+import { ChatBuilder } "./chat";
 
 module {
   public type ChatMessage = Chat.ChatMessage;
@@ -8,13 +9,17 @@ module {
   public type AssistantMessage = Chat.AssistantMessage;
   public type Response = Chat.Response;
   public type Request = Chat.Request;
+  public type ChatBuilder = Chat.ChatBuilder.ChatBuilder;
+  public type ToolBuilder = Tool.ToolBuilder.ToolBuilder;
+  public type ParameterBuilder = Tool.ParameterBuilder.ParameterBuilder;
 
   public func prompt(model : Text, promptStr : Text) : async Text {
-    let response = await Chat.ChatBuilder(model).withMessages([
+    let builder = ChatBuilder.new(model).withMessages([
       #user({
         content = promptStr;
       })
-    ]).send();
+    ]);
+    let response = await ChatBuilder.send(builder);
 
     switch (response.message.content) {
       case (?text) text;
@@ -22,15 +27,15 @@ module {
     };
   };
 
-  public func chat(model : Text) : Chat.ChatBuilder {
-    Chat.ChatBuilder(model);
+  public func chat(model : Text) : ChatBuilder {
+    Chat.ChatBuilder.new(model);
   };
 
-  public func tool(name : Text) : Tool.ToolBuilder {
-    Tool.ToolBuilder(name);
+  public func tool(name : Text) : ToolBuilder {
+    Tool.ToolBuilder.new(name);
   };
 
-  public func parameter(name : Text, type_ : Tool.ParameterType) : Tool.ParameterBuilder {
-    Tool.ParameterBuilder(name, type_);
+  public func parameter(name : Text, type_ : Tool.ParameterType) : ParameterBuilder {
+    Tool.ParameterBuilder.new(name, type_);
   };
 };

--- a/motoko/src/tool.mo
+++ b/motoko/src/tool.mo
@@ -62,115 +62,106 @@ module {
     };
 
     /// Builder for creating a parameter for a function tool.
-    public class ParameterBuilder(name : Text, type_ : ParameterType) = self {
-        private var _name : Text = name;
-        private var _type : ParameterType = type_;
-        private var _description : ?Text = null;
-        private var _required : Bool = false;
-        private var _enum_values : ?[Text] = null;
+    public module ParameterBuilder {
+        public type ParameterBuilder = {
+            name : Text;
+            parameterType : ParameterType;
+            var description : ?Text;
+            var required : Bool;
+            var enumValues : ?[Text];
+        };
+
+        public func new(name : Text, type_ : ParameterType) : ParameterBuilder {
+            {
+                name = name;
+                parameterType = type_;
+                var description = null;
+                var required = false;
+                var enumValues = null;
+            };
+        };
 
         /// Add a description to the parameter.
-        public func withDescription(description : Text) : ParameterBuilder {
-            _description := ?description;
-            return self;
+        public func withDescription(self : ParameterBuilder, description : Text) : ParameterBuilder {
+            self.description := ?description;
+            self;
         };
 
         /// Mark the parameter as required.
-        public func isRequired() : ParameterBuilder {
-            _required := true;
-            return self;
+        public func isRequired(self : ParameterBuilder) : ParameterBuilder {
+            self.required := true;
+            self;
         };
 
         /// Add allowed enum values for the parameter.
-        public func withEnumValues(values : [Text]) : ParameterBuilder {
-            _enum_values := ?values;
-            return self;
-        };
-
-        /// Get the parameter name.
-        public func getName() : Text {
-            _name;
-        };
-
-        /// Get the parameter type.
-        public func getType() : ParameterType {
-            _type;
-        };
-
-        /// Get the parameter description.
-        public func getDescription() : ?Text {
-            _description;
-        };
-
-        /// Check if the parameter is required.
-        public func isRequiredValue() : Bool {
-            _required;
-        };
-
-        /// Get the enum values if any.
-        public func getEnumValues() : ?[Text] {
-            _enum_values;
+        public func withEnumValues(self : ParameterBuilder, values : [Text]) : ParameterBuilder {
+            self.enumValues := ?values;
+            self;
         };
 
         /// Convert the builder to a Property.
-        public func toProperty() : Property {
+        public func toProperty(self : ParameterBuilder) : Property {
             {
-                type_ = parameterTypeToText(_type);
-                name = _name;
-                description = _description;
-                enum_ = _enum_values;
+                type_ = parameterTypeToText(self.parameterType);
+                name = self.name;
+                description = self.description;
+                enum_ = self.enumValues;
             };
         };
     };
 
     /// Builder for creating a function tool.
-    public class ToolBuilder(name : Text) = self {
-        private var function : Function = {
-            name = name;
-            description = null;
-            parameters = null;
+    public module ToolBuilder {
+        public type ToolBuilder = {
+            name : Text;
+            var description : ?Text;
+            var parameters : [ParameterBuilder.ParameterBuilder];
         };
 
-        private var parameters : [ParameterBuilder] = [];
+        public func new(name : Text) : ToolBuilder {
+            {
+                name = name;
+                var description = null;
+                var parameters = [];
+            };
+        };
 
         /// Adds a description to the function.
-        public func withDescription(description : Text) : ToolBuilder {
-            function := {
-                name = function.name;
-                description = ?description;
-                parameters = function.parameters;
-            };
-            return self;
+        public func withDescription(self : ToolBuilder, description : Text) : ToolBuilder {
+            self.description := ?description;
+            self;
         };
 
         /// Adds a parameter to the function.
-        public func withParameter(parameter : ParameterBuilder) : ToolBuilder {
-            parameters := parameters.concat([parameter]);
-            return self;
+        public func withParameter(self : ToolBuilder, parameter : ParameterBuilder.ParameterBuilder) : ToolBuilder {
+            self.parameters := self.parameters.concat([parameter]);
+            self;
         };
 
         /// Builds the final Tool.
-        public func build() : Tool {
-            if (parameters.size() > 0) {
-                let properties = parameters.map<ParameterBuilder, Property>(func(p) { p.toProperty() });
-                let required = parameters
-                    .filter<ParameterBuilder>(func(p) { p.isRequiredValue() })
-                    .map<ParameterBuilder, Text>(func(p) { p.getName() });
-
-                let updatedFunction = {
-                    name = function.name;
-                    description = function.description;
-                    parameters = ?{
-                        type_ = "object";
-                        properties = ?properties;
-                        required = if (required.size() > 0) ?required else null;
-                    };
-                };
-
-                #function(updatedFunction);
-            } else {
-                #function(function);
+        public func build(self : ToolBuilder) : Tool {
+            if (self.parameters.size() == 0) {
+                return #function({
+                    name = self.name;
+                    description = self.description;
+                    parameters = null;
+                });
             };
+
+            let properties = self.parameters.map<ParameterBuilder.ParameterBuilder, Property>(func(p) { p.toProperty() });
+            let required = self.parameters
+                .filter<ParameterBuilder.ParameterBuilder>(func(p) { p.required })
+                .map<ParameterBuilder.ParameterBuilder, Text>(func(p) { p.name });
+
+            #function({
+                name = self.name;
+                description = self.description;
+                parameters = ?{
+                    type_ = "object";
+                    properties = ?properties;
+                    required = if (required.size() > 0) ?required else null;
+                };
+            });
         };
     };
 

--- a/motoko/src/tool.mo
+++ b/motoko/src/tool.mo
@@ -1,4 +1,4 @@
-import Array "mo:base/Array";
+import Array "mo:core/Array";
 
 module {
     /// Represents a tool that can be called by an agent.
@@ -145,24 +145,17 @@ module {
 
         /// Adds a parameter to the function.
         public func withParameter(parameter : ParameterBuilder) : ToolBuilder {
-            parameters := Array.append(parameters, [parameter]);
+            parameters := parameters.concat([parameter]);
             return self;
         };
 
         /// Builds the final Tool.
         public func build() : Tool {
             if (parameters.size() > 0) {
-                let properties = Array.map<ParameterBuilder, Property>(
-                    parameters,
-                    func(p) { p.toProperty() },
-                );
-                let required = Array.map<ParameterBuilder, Text>(
-                    Array.filter<ParameterBuilder>(
-                        parameters,
-                        func(p) { p.isRequiredValue() },
-                    ),
-                    func(p) { p.getName() },
-                );
+                let properties = parameters.map<ParameterBuilder, Property>(func(p) { p.toProperty() });
+                let required = parameters
+                    .filter<ParameterBuilder>(func(p) { p.isRequiredValue() })
+                    .map<ParameterBuilder, Text>(func(p) { p.getName() });
 
                 let updatedFunction = {
                     name = function.name;
@@ -184,12 +177,7 @@ module {
     /// Retrieves the argument of the given `FunctionCall`.
     public func getArgument(functionCall : FunctionCall, argumentName : Text) : ?Text {
         switch (
-            Array.find<ToolCallArgument>(
-                functionCall.arguments,
-                func(arg) : Bool {
-                    arg.name == argumentName;
-                },
-            )
+            functionCall.arguments.find<ToolCallArgument>(func(arg) { arg.name == argumentName })
         ) {
             case (null) { null };
             case (?arg) { ?arg.value };

--- a/motoko/test/chat.test.mo
+++ b/motoko/test/chat.test.mo
@@ -1,11 +1,13 @@
 import Chat "../src/chat";
 import Tool "../src/tool";
+import { ChatBuilder } "../src/chat";
+import { ToolBuilder } "../src/tool";
 import { test } "mo:test";
 
 test(
   "create chat builder",
   func() {
-    let builder = Chat.ChatBuilder("llama3.1:8b");
+    let builder = ChatBuilder.new("llama3.1:8b");
 
     let request = builder.build();
     assert request == {
@@ -24,7 +26,7 @@ test(
       #user { content = "Hello" },
     ];
 
-    let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages);
+    let builder = ChatBuilder.new("llama3.1:8b").withMessages(messages);
 
     let request = builder.build();
     assert request == {
@@ -38,9 +40,9 @@ test(
 test(
   "chat builder with tools",
   func() {
-    let tool = (Tool.ToolBuilder("test_tool")).withDescription("A test tool").build();
+    let tool = ToolBuilder.new("test_tool").withDescription("A test tool").build();
 
-    let builder = Chat.ChatBuilder("llama3.1:8b").withTools([tool]);
+    let builder = ChatBuilder.new("llama3.1:8b").withTools([tool]);
 
     let request = builder.build();
     assert request == {
@@ -58,9 +60,9 @@ test(
       #user { content = "Hello" },
     ];
 
-    let tool = (Tool.ToolBuilder("test_tool")).build();
+    let tool = ToolBuilder.new("test_tool").build();
 
-    let builder = Chat.ChatBuilder("llama3.1:8b").withMessages(messages).withTools([tool]);
+    let builder = ChatBuilder.new("llama3.1:8b").withMessages(messages).withTools([tool]);
 
     let request = builder.build();
     assert request == {
@@ -97,7 +99,7 @@ test(
 test(
   "withCycles is chainable and does not affect build()",
   func() {
-    let builder = Chat.ChatBuilder("gemma3:27b").withCycles();
+    let builder = ChatBuilder.new("gemma3:27b").withCycles();
 
     let request = builder.build();
     assert request == {
@@ -114,9 +116,9 @@ test(
     let messages : [Chat.ChatMessage] = [
       #user { content = "Hello" },
     ];
-    let tool = (Tool.ToolBuilder("test_tool")).build();
+    let tool = ToolBuilder.new("test_tool").build();
 
-    let builder = Chat.ChatBuilder("gemma3:27b").withMessages(messages).withTools([tool]).withCycles();
+    let builder = ChatBuilder.new("gemma3:27b").withMessages(messages).withTools([tool]).withCycles();
 
     let request = builder.build();
     assert request == {

--- a/motoko/test/tool.test.mo
+++ b/motoko/test/tool.test.mo
@@ -1,10 +1,11 @@
 import Tool "../src/tool";
+import { ToolBuilder; ParameterBuilder } "../src/tool";
 import { test } "mo:test";
 
 test(
     "create simple tool",
     func() {
-        let tool = (Tool.ToolBuilder("test_tool")).build();
+        let tool = ToolBuilder.new("test_tool").build();
 
         let expected = #function({
             name = "test_tool";
@@ -19,7 +20,7 @@ test(
 test(
     "tool with description",
     func() {
-        let tool = (Tool.ToolBuilder("test_tool"))
+        let tool = ToolBuilder.new("test_tool")
             .withDescription("This is a test tool")
             .build();
 
@@ -36,9 +37,9 @@ test(
 test(
     "tool with single parameter",
     func() {
-        let tool = (Tool.ToolBuilder("test_tool"))
+        let tool = ToolBuilder.new("test_tool")
             .withParameter(
-                (Tool.ParameterBuilder("param1", #String))
+                ParameterBuilder.new("param1", #String)
                     .withDescription("Test parameter")
                     .isRequired()
             )
@@ -66,19 +67,19 @@ test(
 test(
     "tool with multiple parameters",
     func() {
-        let tool = (Tool.ToolBuilder("weather_tool"))
+        let tool = ToolBuilder.new("weather_tool")
             .withDescription("Get weather information")
             .withParameter(
-                (Tool.ParameterBuilder("location", #String))
+                ParameterBuilder.new("location", #String)
                     .withDescription("City name")
                     .isRequired()
             )
             .withParameter(
-                (Tool.ParameterBuilder("units", #String))
+                ParameterBuilder.new("units", #String)
                     .withDescription("Temperature units")
             )
             .withParameter(
-                (Tool.ParameterBuilder("forecast", #Boolean))
+                ParameterBuilder.new("forecast", #Boolean)
                     .withDescription("Include forecast")
             )
             .build();
@@ -119,9 +120,9 @@ test(
 test(
     "optional parameter",
     func() {
-        let tool = (Tool.ToolBuilder("test_tool"))
+        let tool = ToolBuilder.new("test_tool")
             .withParameter(
-                (Tool.ParameterBuilder("optional_param", #String))
+                ParameterBuilder.new("optional_param", #String)
                     .withDescription("This parameter is optional")
             )
             .build();
@@ -157,10 +158,10 @@ test(
 test(
     "weather tool example",
     func() {
-        let weather_tool = (Tool.ToolBuilder("get_current_weather"))
+        let weather_tool = ToolBuilder.new("get_current_weather")
             .withDescription("Get current weather for a location.")
             .withParameter(
-                (Tool.ParameterBuilder("location", #String))
+                ParameterBuilder.new("location", #String)
                     .withDescription("The location to get the weather for (e.g. Cairo, Egypt)")
                     .isRequired()
             )
@@ -188,10 +189,10 @@ test(
 test(
     "number parameter",
     func() {
-        let tool = (Tool.ToolBuilder("calculator"))
+        let tool = ToolBuilder.new("calculator")
             .withDescription("Perform mathematical calculations")
             .withParameter(
-                (Tool.ParameterBuilder("value", #Number))
+                ParameterBuilder.new("value", #Number)
                     .withDescription("The numeric value to use in calculation")
                     .isRequired()
             )
@@ -219,15 +220,15 @@ test(
 test(
     "enum parameter",
     func() {
-        let tool = (Tool.ToolBuilder("unit_converter"))
+        let tool = ToolBuilder.new("unit_converter")
             .withDescription("Convert between different units")
             .withParameter(
-                (Tool.ParameterBuilder("value", #Number))
+                ParameterBuilder.new("value", #Number)
                     .withDescription("The value to convert")
                     .isRequired()
             )
             .withParameter(
-                (Tool.ParameterBuilder("unit", #String))
+                ParameterBuilder.new("unit", #String)
                     .withDescription("The unit to convert to")
                     .withEnumValues(["meters", "feet", "kilometers", "miles"])
                     .isRequired()


### PR DESCRIPTION
- Replace `base` 0.14.9 with `core` 2.6.1; pin toolchain to moc 1.14.1.
- Rewrite `ChatBuilder`/`ToolBuilder`/`ParameterBuilder` classes as record types with same-named companion modules; chained calls resolve via contextual dot (`ChatBuilder.new(model).withMessages(...).build()`).
- `send` remains a module function called explicitly (`ChatBuilder.send(builder)`): moc does not resolve async functions through contextual dot.

Breaking: consumers construct builders via `new()` and need the companion module in scope for chained calls.

Tests pass on moc 1.14.1 (`mops test`, 15 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)